### PR TITLE
Use ppa for cmake 2.8.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,13 @@
 language: rust
+before_install:
+  # This ppa provides cmake 2.8.11, which travis doesn't have yet
+  - sudo add-apt-repository --yes ppa:kalakris/cmake
+  - sudo apt-get update -qq
 install:
+  - sudo apt-get install cmake
   - sudo apt-get install libXxf86vm-dev
   - sudo apt-get install libsfml-dev
   - sudo apt-get install libjpeg62
-  - sudo apt-get update
   - git clone https://github.com/glfw/glfw.git
   - cd glfw
   - git checkout 3.0.3


### PR DESCRIPTION
This fixes a build failure in Travis CI. The build gets past the cmake failure in my fork but then hits a problem in glfw: https://travis-ci.org/bstpierre/nphysics/builds/67459074