### PR TITLE
Update to the last ncollide api + minor method renaming.

### DIFF
--- a/examples2/cross.rs
+++ b/examples2/cross.rs
@@ -63,8 +63,8 @@ fn main() {
     let centerx = shift * (num as f32) / 2.0;
     let centery = shift * (num as f32) / 2.0;
 
-    for i in (0usize .. num) {
-        for j in (0usize .. num) {
+    for i in 0usize .. num {
+        for j in 0usize .. num {
             let x = i as f32 * 2.5 * rad - centerx;
             let y = j as f32 * 2.5 * rad - centery * 2.0 - 250.0;
 

--- a/examples2/gravity.rs
+++ b/examples2/gravity.rs
@@ -45,7 +45,7 @@ fn main() {
     let centerx = shift * (num as f32) / 2.0;
     let centery = 2.0;
 
-    for i in (0usize .. num) {
+    for i in 0usize .. num {
         for j in 0usize .. 2 {
             let x = i as f32 * 2.5 * rad - centerx;
             let y = j as f32 * 2.5 * rad - centery * 2.0;

--- a/src/detection/joint/joint_manager.rs
+++ b/src/detection/joint/joint_manager.rs
@@ -48,7 +48,7 @@ impl JointManager {
                               Constraint::BallInSocket(joint.clone())) {
             match joint.borrow().anchor1().body.as_ref() {
                 Some(b) => {
-                    activation.will_activate(b);
+                    activation.deferred_activate(b);
                     let js = self.body2joints.find_or_insert_lazy(&**b as *const RefCell<RigidBody> as usize,
                                                                   || Some(Vec::new()));
                     js.unwrap().push(Constraint::BallInSocket(joint.clone()));
@@ -58,7 +58,7 @@ impl JointManager {
 
             match joint.borrow().anchor2().body.as_ref() {
                 Some(b) => {
-                    activation.will_activate(b);
+                    activation.deferred_activate(b);
                     let js = self.body2joints.find_or_insert_lazy(&**b as *const RefCell<RigidBody> as usize,
                                                                   || Some(Vec::new()));
                     js.unwrap().push(Constraint::BallInSocket(joint.clone()));
@@ -73,8 +73,8 @@ impl JointManager {
     /// This will force the activation of the two objects attached to the joint.
     pub fn remove_ball_in_socket(&mut self, joint: &Rc<RefCell<BallInSocket>>, activation: &mut ActivationManager) {
         if self.joints.remove(&(&**joint as *const RefCell<BallInSocket> as usize)) {
-            let _  = joint.borrow().anchor1().body.as_ref().map(|b| activation.will_activate(b));
-            let _  = joint.borrow().anchor2().body.as_ref().map(|b| activation.will_activate(b));
+            let _  = joint.borrow().anchor1().body.as_ref().map(|b| activation.deferred_activate(b));
+            let _  = joint.borrow().anchor2().body.as_ref().map(|b| activation.deferred_activate(b));
         }
     }
 
@@ -85,7 +85,7 @@ impl JointManager {
         if self.joints.insert(&*joint as *const RefCell<Fixed> as usize, Constraint::Fixed(joint.clone())) {
             match joint.borrow().anchor1().body.as_ref() {
                 Some(b) => {
-                    activation.will_activate(b);
+                    activation.deferred_activate(b);
                     let js = self.body2joints.find_or_insert_lazy(&**b as *const RefCell<RigidBody> as usize,
                                                                   || Some(Vec::new()));
                     js.unwrap().push(Constraint::Fixed(joint.clone()));
@@ -95,7 +95,7 @@ impl JointManager {
 
             match joint.borrow().anchor2().body.as_ref() {
                 Some(b) => {
-                    activation.will_activate(b);
+                    activation.deferred_activate(b);
                     let js = self.body2joints.find_or_insert_lazy(&**b as *const RefCell<RigidBody> as usize,
                                                                   || Some(Vec::new()));
                     js.unwrap().push(Constraint::Fixed(joint.clone()));
@@ -123,7 +123,7 @@ impl JointManager {
                                              activation: &mut ActivationManager) {
         match body {
             Some(b) => {
-                activation.will_activate(b);
+                activation.deferred_activate(b);
                 let key = &**b as *const RefCell<RigidBody> as usize;
                 match self.body2joints.find_mut(&key) {
                     Some(ref mut js) => {
@@ -191,11 +191,11 @@ impl JointManager {
                         // the joint has been invalidated by the user: wake up the attached bodies
                         bbis.update();
                         match bbis.anchor1().body {
-                            Some(ref b) => activation.will_activate(b),
+                            Some(ref b) => activation.deferred_activate(b),
                             None        => { }
                         }
                         match bbis.anchor2().body {
-                            Some(ref b) => activation.will_activate(b),
+                            Some(ref b) => activation.deferred_activate(b),
                             None        => { }
                         }
                     }
@@ -206,11 +206,11 @@ impl JointManager {
                         // the joint has been invalidated by the user: wake up the attached bodies
                         bf.update();
                         match bf.anchor1().body {
-                            Some(ref b) => activation.will_activate(b),
+                            Some(ref b) => activation.deferred_activate(b),
                             None        => { }
                         }
                         match bf.anchor2().body {
-                            Some(ref b) => activation.will_activate(b),
+                            Some(ref b) => activation.deferred_activate(b),
                             None        => { }
                         }
                     }

--- a/src/integration/translational_ccd_motion_clamping.rs
+++ b/src/integration/translational_ccd_motion_clamping.rs
@@ -132,7 +132,7 @@ impl TranslationalCCDMotionClamping {
                 /*
                  * We moved the object: ensure the broad phase takes that in account.
                  */
-                cw.defered_set_position(&* o.value.body as *const RefCell<RigidBody> as usize, o.value.body.borrow().position().clone());
+                cw.deferred_set_position(&* o.value.body as *const RefCell<RigidBody> as usize, o.value.body.borrow().position().clone());
                 update_collision_world = true;
             }
 


### PR DESCRIPTION
This makes objects removal operational and renames the method `.will_activate(...)` of the
`ActivationManager` to `.deferred_activate(...)`.