### PR TITLE
Make everything generic wrt. the scalar type.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,6 @@ For the 3D version, add the crate named `nphysics3d`:
 nphysics3d = "0.1.*"
 ```
 
-By default, 32-bit floating point numbers are used by the library. If you need
-more accuracy, use either version of nphysics with the feature `f64` enabled.
-For example:
-
-```ignore
-[dependencies.nphysics2d]
-version  = "0.1.*"
-features = "f64"
-```
-
 Use `make examples` to build the demos and execute `./your_favorite_example_here --help`
 to see all the cool stuffs you can do.
 

--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nphysics2d"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://nphysics.org/doc/nphysics2d"
@@ -11,10 +11,8 @@ keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
 license = "BSD-3-Clause"
 
 [features]
-default = [ "dim2", "f32" ]
+default = [ "dim2" ]
 dim2    = [ ]
-f32     = [ ]
-f64     = [ ]
 
 [lib]
 name = "nphysics2d"

--- a/build/nphysics2d/Makefile
+++ b/build/nphysics2d/Makefile
@@ -1,10 +1,8 @@
 all:
 	cargo build
-	cargo build --features "f64"
 
 doc:
 	cargo doc --no-deps
 
 test:
 	cargo test
-	cargo test --features "f64"

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nphysics3d"
-version = "0.1.2"
+version = "0.2.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://nphysics.org/doc/nphysics3d"
@@ -11,10 +11,8 @@ keywords = [ "physics", "dynamics", "rigid", "real-time", "joints" ]
 license = "BSD-3-Clause"
 
 [features]
-default = [ "dim3", "f32" ]
+default = [ "dim3" ]
 dim3    = [ ]
-f32     = [ ]
-f64     = [ ]
 
 [lib]
 name = "nphysics3d"

--- a/build/nphysics3d/Makefile
+++ b/build/nphysics3d/Makefile
@@ -1,10 +1,8 @@
 all:
 	cargo build
-	cargo build --features "f64"
 
 doc:
 	cargo doc --no-deps
 
 test:
 	cargo test
-	cargo test --features "f64"

--- a/examples2d/balls_vee.rs
+++ b/examples2d/balls_vee.rs
@@ -19,14 +19,14 @@ fn main() {
 }
 
 
-fn create_the_world() -> World {
+fn create_the_world() -> World<f32> {
     let mut world = World::new();
     world.set_gravity(Vec2::new(0.0, 9.81));
     world
 }
 
 
-fn create_the_walls(world: &mut World) {
+fn create_the_walls(world: &mut World<f32>) {
     /*
      * First plane
      */
@@ -43,7 +43,7 @@ fn create_the_walls(world: &mut World) {
 }
 
 
-fn create_the_balls(world: &mut World) {
+fn create_the_balls(world: &mut World<f32>) {
     let num     = (4000.0f32.sqrt()) as usize;
     let rad     = 0.5;
     let shift   = 2.5 * rad;
@@ -65,7 +65,7 @@ fn create_the_balls(world: &mut World) {
 }
 
 
-fn run_simulation(world: World) {
+fn run_simulation(world: World<f32>) {
     let mut testbed = Testbed::new(world);
 
     testbed.run();

--- a/examples2d/nphysics_testbed2d/src/draw_helper.rs
+++ b/examples2d/nphysics_testbed2d/src/draw_helper.rs
@@ -11,7 +11,7 @@ use nphysics2d::detection::joint::Joint;
 pub static DRAW_SCALE: f32 = 20.0;
 
 pub fn draw_colls(window:  &mut graphics::RenderWindow,
-                  physics: &mut World) {
+                  physics: &mut World<f32>) {
 
     let mut collisions = Vec::new();
 

--- a/examples2d/nphysics_testbed2d/src/engine.rs
+++ b/examples2d/nphysics_testbed2d/src/engine.rs
@@ -57,7 +57,7 @@ impl<'a> GraphicsManager<'a> {
         }
     }
 
-    pub fn add(&mut self, body: Rc<RefCell<RigidBody>>) {
+    pub fn add(&mut self, body: Rc<RefCell<RigidBody<f32>>>) {
 
         let nodes = {
             let rb    = body.borrow();
@@ -68,11 +68,11 @@ impl<'a> GraphicsManager<'a> {
             nodes
         };
 
-        self.rb2sn.insert(&*body as *const RefCell<RigidBody> as usize, nodes);
+        self.rb2sn.insert(&*body as *const RefCell<RigidBody<f32>> as usize, nodes);
     }
 
     fn add_shape(&mut self,
-                 body:  Rc<RefCell<RigidBody>>,
+                 body:  Rc<RefCell<RigidBody<f32>>>,
                  delta: Iso2<f32>,
                  shape: &Repr2<f32>,
                  out:   &mut Vec<SceneNode<'a>>) {
@@ -118,13 +118,13 @@ impl<'a> GraphicsManager<'a> {
     }
 
     fn add_plane(&mut self,
-                 _: Rc<RefCell<RigidBody>>,
+                 _: Rc<RefCell<RigidBody<f32>>>,
                  _: &shape::Plane2<f32>,
                  _: &mut Vec<SceneNode>) {
     }
 
     fn add_ball(&mut self,
-                body:  Rc<RefCell<RigidBody>>,
+                body:  Rc<RefCell<RigidBody<f32>>>,
                 delta: Iso2<f32>,
                 shape: &shape::Ball2<f32>,
                 out:   &mut Vec<SceneNode>) {
@@ -134,7 +134,7 @@ impl<'a> GraphicsManager<'a> {
     }
     
     fn add_convex(&mut self,
-                body:  Rc<RefCell<RigidBody>>,
+                body:  Rc<RefCell<RigidBody<f32>>>,
                 delta: Iso2<f32>,
                 shape: &shape::Convex2<f32>,
                 out:   &mut Vec<SceneNode>) {
@@ -152,7 +152,7 @@ impl<'a> GraphicsManager<'a> {
     }
 
     fn add_lines(&mut self,
-                 body:  Rc<RefCell<RigidBody>>,
+                 body:  Rc<RefCell<RigidBody<f32>>>,
                  delta: Iso2<f32>,
                  shape: &shape::Polyline2<f32>,
                  out:   &mut Vec<SceneNode>) {
@@ -167,7 +167,7 @@ impl<'a> GraphicsManager<'a> {
 
 
     fn add_box(&mut self,
-               body:  Rc<RefCell<RigidBody>>,
+               body:  Rc<RefCell<RigidBody<f32>>>,
                delta: Iso2<f32>,
                shape: &shape::Cuboid2<f32>,
                out:   &mut Vec<SceneNode>) {
@@ -181,7 +181,7 @@ impl<'a> GraphicsManager<'a> {
     }
 
     fn add_segment(&mut self,
-                   body:  Rc<RefCell<RigidBody>>,
+                   body:  Rc<RefCell<RigidBody<f32>>>,
                    delta: Iso2<f32>,
                    shape: &shape::Segment2<f32>,
                    out:   &mut Vec<SceneNode>) {
@@ -226,13 +226,13 @@ impl<'a> GraphicsManager<'a> {
         c.activate_ui(rw);
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody>>, color: Pnt3<u8>) {
-        let key = &**body as *const RefCell<RigidBody> as usize;
+    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<u8>) {
+        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
         self.obj2color.insert(key, color);
     }
 
-    pub fn color_for_object(&mut self, body: &Rc<RefCell<RigidBody>>) -> Pnt3<u8> {
-        let key = &**body as *const RefCell<RigidBody> as usize;
+    pub fn color_for_object(&mut self, body: &Rc<RefCell<RigidBody<f32>>>) -> Pnt3<u8> {
+        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
         match self.obj2color.get(&key) {
             Some(color) => return *color,
             None => { }
@@ -249,7 +249,7 @@ impl<'a> GraphicsManager<'a> {
         color
     }
 
-    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody>>) -> Option<&mut Vec<SceneNode<'a>>> {
-        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody> as usize))
+    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>) -> Option<&mut Vec<SceneNode<'a>>> {
+        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody<f32>> as usize))
     }
 }

--- a/examples2d/nphysics_testbed2d/src/objects/ball.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/ball.rs
@@ -13,12 +13,12 @@ pub struct Ball<'a> {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body:  Rc<RefCell<RigidBody>>,
+    body:  Rc<RefCell<RigidBody<f32>>>,
     gfx:   CircleShape<'a>
 }
 
 impl<'a> Ball<'a> {
-    pub fn new(body:   Rc<RefCell<RigidBody>>,
+    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso2<f32>,
                radius: f32,
                color:  Pnt3<u8>) -> Ball<'a> {

--- a/examples2d/nphysics_testbed2d/src/objects/box_node.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/box_node.rs
@@ -13,12 +13,12 @@ pub struct Box<'a> {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body: Rc<RefCell<RigidBody>>,
+    body: Rc<RefCell<RigidBody<f32>>>,
     gfx: RectangleShape<'a>
 }
 
 impl<'a> Box<'a> {
-    pub fn new(body:  Rc<RefCell<RigidBody>>,
+    pub fn new(body:  Rc<RefCell<RigidBody<f32>>>,
                delta: Iso2<f32>,
                rx:    f32,
                ry:    f32,

--- a/examples2d/nphysics_testbed2d/src/objects/lines.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/lines.rs
@@ -11,13 +11,13 @@ pub struct Lines {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body: Rc<RefCell<RigidBody>>,
+    body: Rc<RefCell<RigidBody<f32>>>,
     indices: Arc<Vec<Pnt2<usize>>>,
     vertices: Arc<Vec<Pnt2<f32>>>
 }
 
 impl Lines {
-    pub fn new(body:     Rc<RefCell<RigidBody>>,
+    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
                delta:    Iso2<f32>,
                vertices: Arc<Vec<Pnt2<f32>>>,
                indices:  Arc<Vec<Pnt2<usize>>>,

--- a/examples2d/nphysics_testbed2d/src/objects/segment.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/segment.rs
@@ -10,13 +10,13 @@ pub struct Segment {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body:  Rc<RefCell<RigidBody>>,
+    body:  Rc<RefCell<RigidBody<f32>>>,
     a:     Pnt2<f32>,
     b:     Pnt2<f32>,
 }
 
 impl Segment {
-    pub fn new(body:     Rc<RefCell<RigidBody>>,
+    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
                delta:    Iso2<f32>,
                a:        Pnt2<f32>,
                b:        Pnt2<f32>,

--- a/examples2d/nphysics_testbed2d/src/testbed.rs
+++ b/examples2d/nphysics_testbed2d/src/testbed.rs
@@ -53,7 +53,7 @@ pub enum CallBackId {
 }
 
 pub struct Testbed<'a> {
-    world:     World,
+    world:     World<f32>,
     callbacks: [Option<Box<Fn(CallBackMode)>>; 9],
     window:    RenderWindow,
     graphics:  GraphicsManager<'a>
@@ -65,8 +65,8 @@ struct TestbedState<'a> {
     cb_states: [bool; 9],
     camera: Camera,
     fps: Fps<'a>,
-    grabbed_object: Option<Rc<RefCell<RigidBody>>>,
-    grabbed_object_joint: Option<Rc<RefCell<Fixed>>>,
+    grabbed_object: Option<Rc<RefCell<RigidBody<f32>>>>,
+    grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>>,
 }
 
 impl<'a> TestbedState<'a> {
@@ -108,7 +108,7 @@ impl<'a> Testbed<'a> {
         }
     }
 
-    pub fn new(world: World) -> Testbed<'a> {
+    pub fn new(world: World<f32>) -> Testbed<'a> {
         let mut res = Testbed::new_empty();
 
         res.set_world(world);
@@ -116,7 +116,7 @@ impl<'a> Testbed<'a> {
         res
     }
 
-    pub fn set_world(&mut self, world: World) {
+    pub fn set_world(&mut self, world: World<f32>) {
         self.world = world;
         self.graphics.clear();
 
@@ -125,7 +125,7 @@ impl<'a> Testbed<'a> {
         }
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody>>, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
         let color = Pnt3::new(
             (color.x * 255.0) as u8,
             (color.y * 255.0) as u8,

--- a/examples2d/ragdoll.rs
+++ b/examples2d/ragdoll.rs
@@ -47,7 +47,7 @@ fn main() {
     testbed.run();
 }
 
-fn add_ragdoll(pos: Vec2<f32>, world: &mut World) {
+fn add_ragdoll(pos: Vec2<f32>, world: &mut World<f32>) {
     // head
     let     head_geom = Ball::new(0.8);
     let mut head      = RigidBody::new_dynamic(head_geom, 1.0, 0.3, 0.5);

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -79,7 +79,7 @@ impl Node {
         }
     }
 
-    pub fn body<'a>(&'a self) -> &'a Rc<RefCell<RigidBody>> {
+    pub fn body<'a>(&'a self) -> &'a Rc<RefCell<RigidBody<f32>>> {
         match *self {
             Node::Plane(ref n)             => n.body(),
             Node::Ball(ref n)              => n.body(),
@@ -140,8 +140,8 @@ impl GraphicsManager {
         self.aabbs.clear();
     }
 
-    pub fn remove(&mut self, window: &mut Window, body: &Rc<RefCell<RigidBody>>) {
-        let key = &**body as *const RefCell<RigidBody> as usize;
+    pub fn remove(&mut self, window: &mut Window, body: &Rc<RefCell<RigidBody<f32>>>) {
+        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
 
         match self.rb2sn.get(&key) {
             Some(sns) => {
@@ -155,14 +155,14 @@ impl GraphicsManager {
         self.rb2sn.remove(&key);
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody>>, color: Pnt3<f32>) {
-        self.rb2color.insert(&**body as *const RefCell<RigidBody> as usize, color);
+    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
+        self.rb2color.insert(&**body as *const RefCell<RigidBody<f32>> as usize, color);
     }
 
-    pub fn add(&mut self, window: &mut Window, body: Rc<RefCell<RigidBody>>) {
+    pub fn add(&mut self, window: &mut Window, body: Rc<RefCell<RigidBody<f32>>>) {
         let color;
 
-        match self.rb2color.get(&(&*body as *const RefCell<RigidBody> as usize)) {
+        match self.rb2color.get(&(&*body as *const RefCell<RigidBody<f32>> as usize)) {
             Some(c) => color = *c,
             None    => {
                 if body.borrow().can_move() {
@@ -179,7 +179,7 @@ impl GraphicsManager {
 
     pub fn add_with_color(&mut self,
                           window: &mut Window,
-                          body:   Rc<RefCell<RigidBody>>,
+                          body:   Rc<RefCell<RigidBody<f32>>>,
                           color:  Pnt3<f32>) {
         let nodes = {
             let rb        = body.borrow();
@@ -190,12 +190,12 @@ impl GraphicsManager {
             nodes
         };
 
-        self.rb2sn.insert(&*body as *const RefCell<RigidBody> as usize, nodes);
+        self.rb2sn.insert(&*body as *const RefCell<RigidBody<f32>> as usize, nodes);
     }
 
     fn add_repr(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody>>,
+                body:   Rc<RefCell<RigidBody<f32>>>,
                 delta:  Iso3<f32>,
                 shape:  &Repr3<f32>,
                 color:  Pnt3<f32>,
@@ -245,7 +245,7 @@ impl GraphicsManager {
 
     fn add_plane(&mut self,
                  window: &mut Window,
-                 body:   Rc<RefCell<RigidBody>>,
+                 body:   Rc<RefCell<RigidBody<f32>>>,
                  shape:   &shape::Plane3<f32>,
                  color:  Pnt3<f32>,
                  out:    &mut Vec<Node>) {
@@ -257,7 +257,7 @@ impl GraphicsManager {
 
     fn add_mesh(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody>>,
+                body:   Rc<RefCell<RigidBody<f32>>>,
                 delta:  Iso3<f32>,
                 shape:   &shape::TriMesh3<f32>,
                 color:  Pnt3<f32>,
@@ -272,7 +272,7 @@ impl GraphicsManager {
 
     fn add_ball(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody>>,
+                body:   Rc<RefCell<RigidBody<f32>>>,
                 delta:  Iso3<f32>,
                 shape:   &shape::Ball3<f32>,
                 color:  Pnt3<f32>,
@@ -283,7 +283,7 @@ impl GraphicsManager {
 
     fn add_box(&mut self,
                window: &mut Window,
-               body:   Rc<RefCell<RigidBody>>,
+               body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso3<f32>,
                shape:   &shape::Cuboid3<f32>,
                color:  Pnt3<f32>,
@@ -297,7 +297,7 @@ impl GraphicsManager {
 
     fn add_convex(&mut self,
                   window: &mut Window,
-                  body:   Rc<RefCell<RigidBody>>,
+                  body:   Rc<RefCell<RigidBody<f32>>>,
                   delta:  Iso3<f32>,
                   shape:   &shape::Convex3<f32>,
                   color:  Pnt3<f32>,
@@ -307,7 +307,7 @@ impl GraphicsManager {
 
     fn add_cylinder(&mut self,
                     window: &mut Window,
-                    body:   Rc<RefCell<RigidBody>>,
+                    body:   Rc<RefCell<RigidBody<f32>>>,
                     delta:  Iso3<f32>,
                     shape:   &shape::Cylinder3<f32>,
                     color:  Pnt3<f32>,
@@ -320,7 +320,7 @@ impl GraphicsManager {
 
     fn add_cone(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody>>,
+                body:   Rc<RefCell<RigidBody<f32>>>,
                 delta:  Iso3<f32>,
                 shape:   &shape::Cone3<f32>,
                 color:  Pnt3<f32>,
@@ -383,7 +383,7 @@ impl GraphicsManager {
         self.first_person.look_at(eye, at);
     }
 
-    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody>>) -> Option<&mut Vec<Node>> {
-        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody> as usize))
+    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>) -> Option<&mut Vec<Node>> {
+        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody<f32>> as usize))
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/ball.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/ball.rs
@@ -10,11 +10,11 @@ pub struct Ball {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>
+    body:       Rc<RefCell<RigidBody<f32>>>
 }
 
 impl Ball {
-    pub fn new(body:   Rc<RefCell<RigidBody>>,
+    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso3<f32>,
                radius: f32,
                color:  Pnt3<f32>,
@@ -60,7 +60,7 @@ impl Ball {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/box_node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/box_node.rs
@@ -10,11 +10,11 @@ pub struct Box {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>,
+    body:       Rc<RefCell<RigidBody<f32>>>,
 }
 
 impl Box {
-    pub fn new(body:   Rc<RefCell<RigidBody>>,
+    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso3<f32>,
                rx:     f32,
                ry:     f32,
@@ -65,7 +65,7 @@ impl Box {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cone.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cone.rs
@@ -10,11 +10,11 @@ pub struct Cone {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>,
+    body:       Rc<RefCell<RigidBody<f32>>>,
 }
 
 impl Cone {
-    pub fn new(body:   Rc<RefCell<RigidBody>>,
+    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso3<f32>,
                r:      f32,
                h:      f32,
@@ -61,7 +61,7 @@ impl Cone {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/convex.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/convex.rs
@@ -12,11 +12,11 @@ pub struct Convex {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>
+    body:       Rc<RefCell<RigidBody<f32>>>
 }
 
 impl Convex {
-    pub fn new(body:     Rc<RefCell<RigidBody>>,
+    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
                delta:    Iso3<f32>,
                convex:   &TriMesh<Pnt3<f32>>,
                color:    Pnt3<f32>,
@@ -65,7 +65,7 @@ impl Convex {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
@@ -10,11 +10,11 @@ pub struct Cylinder {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>,
+    body:       Rc<RefCell<RigidBody<f32>>>,
 }
 
 impl Cylinder {
-    pub fn new(body:   Rc<RefCell<RigidBody>>,
+    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
                delta:  Iso3<f32>,
                r:     f32,
                h:     f32,
@@ -60,7 +60,7 @@ impl Cylinder {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/mesh.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/mesh.rs
@@ -12,11 +12,11 @@ pub struct Mesh {
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody>>
+    body:       Rc<RefCell<RigidBody<f32>>>
 }
 
 impl Mesh {
-    pub fn new(body:     Rc<RefCell<RigidBody>>,
+    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
                delta:    Iso3<f32>,
                vertices: Vec<Pnt3<f32>>,
                indices:  Vec<Pnt3<u32>>,
@@ -71,7 +71,7 @@ impl Mesh {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/plane.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/plane.rs
@@ -8,11 +8,11 @@ use nphysics3d::object::RigidBody;
 
 pub struct Plane {
     gfx:  SceneNode,
-    body: Rc<RefCell<RigidBody>>
+    body: Rc<RefCell<RigidBody<f32>>>
 }
 
 impl Plane {
-    pub fn new(body:         Rc<RefCell<RigidBody>>,
+    pub fn new(body:         Rc<RefCell<RigidBody<f32>>>,
                world_pos:    &Pnt3<f32>,
                world_normal: &Vec3<f32>,
                color:        Pnt3<f32>,
@@ -54,7 +54,7 @@ impl Plane {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody>> {
+    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/testbed.rs
+++ b/examples3d/nphysics_testbed3d/src/testbed.rs
@@ -46,7 +46,7 @@ fn usage(exe_name: &str) {
 }
 
 pub struct Testbed {
-    world:    World,
+    world:    World<f32>,
     window:   Window,
     graphics: GraphicsManager,
 }
@@ -63,7 +63,7 @@ impl Testbed {
         }
     }
 
-    pub fn new(world: World) -> Testbed {
+    pub fn new(world: World<f32>) -> Testbed {
         let mut res = Testbed::new_empty();
 
         res.set_world(world);
@@ -71,7 +71,7 @@ impl Testbed {
         res
     }
 
-    pub fn set_world(&mut self, world: World) {
+    pub fn set_world(&mut self, world: World<f32>) {
         self.world = world;
 
         self.graphics.clear(&mut self.window);
@@ -85,7 +85,7 @@ impl Testbed {
         self.graphics.look_at(eye, at);
     }
 
-    pub fn set_color(&mut self, rb: &Rc<RefCell<RigidBody>>, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
         self.graphics.set_color(rb, color);
     }
 
@@ -138,8 +138,8 @@ impl Testbed {
         let mut draw_colls = false;
 
         let mut cursor_pos = Pnt2::new(0.0f32, 0.0);
-        let mut grabbed_object: Option<Rc<RefCell<RigidBody>>> = None;
-        let mut grabbed_object_joint: Option<Rc<RefCell<Fixed>>> = None;
+        let mut grabbed_object: Option<Rc<RefCell<RigidBody<f32>>>> = None;
+        let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
         let mut grabbed_object_plane: (Pnt3<f32>, Vec3<f32>) = (na::orig(), na::zero());
 
 
@@ -343,12 +343,12 @@ impl Testbed {
 
                         {
                             let cam      = self.graphics.camera();
-                            cam_transfom = cam.view_transform();
+                            cam_transfom = na::inv(&cam.view_transform()).unwrap();
                         }
 
                         rb.append_translation(&na::translation(&cam_transfom));
 
-                        let front = na::rotate(&cam_transfom, &Vec3::z());
+                        let front = -na::rotate(&cam_transfom, &Vec3::z());
 
                         rb.set_lin_vel(front * 40.0f32);
 
@@ -363,12 +363,12 @@ impl Testbed {
 
                         {
                             let cam = self.graphics.camera();
-                            cam_transform = cam.view_transform();
+                            cam_transform = na::inv(&cam.view_transform()).unwrap();
                         }
 
                         rb.append_translation(&na::translation(&cam_transform));
 
-                        let front = na::rotate(&cam_transform, &Vec3::z());
+                        let front = -na::rotate(&cam_transform, &Vec3::z());
 
                         rb.set_lin_vel(front * 40.0f32);
 
@@ -422,7 +422,7 @@ enum RunMode {
     Step
 }
 
-fn draw_collisions(window: &mut Window, physics: &mut World) {
+fn draw_collisions(window: &mut Window, physics: &mut World<f32>) {
     let mut collisions = Vec::new();
 
     physics.interferences(&mut collisions);

--- a/examples3d/ragdoll.rs
+++ b/examples3d/ragdoll.rs
@@ -52,7 +52,7 @@ fn main() {
     testbed.run();
 }
 
-fn add_ragdoll(pos: Vec3<f32>, world: &mut World) {
+fn add_ragdoll(pos: Vec3<f32>, world: &mut World<f32>) {
     // head
     let     head_geom = Ball::new(0.8);
     let mut head      = RigidBody::new_dynamic(head_geom, 1.0, 0.3, 0.5);

--- a/src/aliases/mod.rs
+++ b/src/aliases/mod.rs
@@ -9,4 +9,4 @@ use object::RigidBody;
 use math::Point;
 
 /// The type of the broad phase used by the world by default.
-pub type DefaultBroadPhase = DBVTBroadPhase<Point, Rc<RefCell<RigidBody>>, AABB<Point>>;
+pub type DefaultBroadPhase<N> = DBVTBroadPhase<Point<N>, Rc<RefCell<RigidBody<N>>>, AABB<Point<N>>>;

--- a/src/detection/constraint.rs
+++ b/src/detection/constraint.rs
@@ -2,23 +2,24 @@
 
 use std::rc::Rc;
 use std::cell::RefCell;
+use ncollide::math::Scalar;
 use ncollide::geometry::Contact;
 use object::RigidBody;
 use detection::joint::{Fixed, BallInSocket};
 use math::Point;
 
 /// A constraint between two rigid bodies.
-pub enum Constraint {
+pub enum Constraint<N: Scalar> {
     /// A contact.
-    RBRB(Rc<RefCell<RigidBody>>, Rc<RefCell<RigidBody>>, Contact<Point>),
+    RBRB(Rc<RefCell<RigidBody<N>>>, Rc<RefCell<RigidBody<N>>>, Contact<Point<N>>),
     /// A ball-in-socket joint.
-    BallInSocket(Rc<RefCell<BallInSocket>>),
+    BallInSocket(Rc<RefCell<BallInSocket<N>>>),
     /// A fixed joint.
-    Fixed(Rc<RefCell<Fixed>>),
+    Fixed(Rc<RefCell<Fixed<N>>>),
 }
 
-impl Clone for Constraint {
-    fn clone(&self) -> Constraint {
+impl<N: Scalar> Clone for Constraint<N> {
+    fn clone(&self) -> Constraint<N> {
         match *self {
             Constraint::RBRB(ref a, ref b, ref c) => Constraint::RBRB(a.clone(), b.clone(), c.clone()),
             Constraint::BallInSocket(ref bis) => Constraint::BallInSocket(bis.clone()),

--- a/src/detection/detector.rs
+++ b/src/detection/detector.rs
@@ -1,12 +1,13 @@
 //! Collision detector.
 
+use ncollide::math::Scalar;
 use detection::activation_manager::ActivationManager;
 
 /// Trait implemented by collision detectors.
-pub trait Detector<I, BF> {
+pub trait Detector<N: Scalar, I, BF> {
     /// Updates the collision detector, given an (already updated) broad-phase, and an activation
     /// manager.
-    fn update(&mut self, &mut BF, &mut ActivationManager);
+    fn update(&mut self, &mut BF, &mut ActivationManager<N>);
     /// Collects every interferences detected by this collision detector.
     fn interferences(&mut self, &mut Vec<I>, &mut BF);
 }

--- a/src/detection/joint/anchor.rs
+++ b/src/detection/joint/anchor.rs
@@ -1,23 +1,24 @@
 use std::rc::Rc;
 use std::cell::RefCell;
-use object::RigidBody;
 use na;
+use ncollide::math::Scalar;
+use object::RigidBody;
 use math::Point;
 
 /// One of the two end points of a joint.
-pub struct Anchor<P> {
+pub struct Anchor<N: Scalar, P> {
     /// The body attached to this anchor.
-    pub body:     Option<Rc<RefCell<RigidBody>>>,
+    pub body:     Option<Rc<RefCell<RigidBody<N>>>>,
     /// The attach position, in local coordinates of the attached body.
     pub position: P
 }
 
-impl<P> Anchor<P> {
+impl<N: Scalar, P> Anchor<N, P> {
     /// Creates a new `Anchor` at a given `position` on a `body` local space.
     ///
     /// If `body` is `None`, the anchor is concidered to be attached to the ground and `position`
     /// is the attach point in global coordinates.
-    pub fn new(body: Option<Rc<RefCell<RigidBody>>>, position: P) -> Anchor<P> {
+    pub fn new(body: Option<Rc<RefCell<RigidBody<N>>>>, position: P) -> Anchor<N, P> {
         Anchor {
             body:     body,
             position: position
@@ -25,11 +26,11 @@ impl<P> Anchor<P> {
     }
 }
 
-impl<P> Anchor<P> {
+impl<N: Scalar, P> Anchor<N, P> {
     /// The center of mass of the body attached to this anchor.
     ///
     /// Returns the zero vector if no body is attached.
-    pub fn center_of_mass(&self) -> Point {
+    pub fn center_of_mass(&self) -> Point<N> {
         match self.body {
             Some(ref b) => {
                 let rb = b.borrow();

--- a/src/detection/joint/ball_in_socket.rs
+++ b/src/detection/joint/ball_in_socket.rs
@@ -1,4 +1,5 @@
 use na::Transform;
+use ncollide::math::Scalar;
 use math::Point;
 use detection::joint::anchor::Anchor;
 use detection::joint::joint::Joint;
@@ -6,15 +7,15 @@ use detection::joint::joint::Joint;
 /// A ball-in-socket joint.
 ///
 /// This is usually used to create ragdolls.
-pub struct BallInSocket {
+pub struct BallInSocket<N: Scalar> {
     up_to_date: bool,
-    anchor1:    Anchor<Point>,
-    anchor2:    Anchor<Point>,
+    anchor1:    Anchor<N, Point<N>>,
+    anchor2:    Anchor<N, Point<N>>,
 }
 
-impl BallInSocket {
+impl<N: Scalar> BallInSocket<N> {
     /// Creates a ball-in-socket joint.
-    pub fn new(anchor1: Anchor<Point>, anchor2: Anchor<Point>) -> BallInSocket {
+    pub fn new(anchor1: Anchor<N, Point<N>>, anchor2: Anchor<N, Point<N>>) -> BallInSocket<N> {
         BallInSocket {
             up_to_date: false,
             anchor1:    anchor1,
@@ -35,7 +36,7 @@ impl BallInSocket {
     /// Sets the the second anchor position.
     ///
     /// The position is expressed in the second attached body’s local coordinates.
-    pub fn set_local1(&mut self, local1: Point) {
+    pub fn set_local1(&mut self, local1: Point<N>) {
         if local1 != self.anchor1.position {
             self.up_to_date = false;
             self.anchor1.position = local1
@@ -45,7 +46,7 @@ impl BallInSocket {
     /// Sets the the second anchor position.
     ///
     /// The position is expressed in the second attached body’s local coordinates.
-    pub fn set_local2(&mut self, local2: Point) {
+    pub fn set_local2(&mut self, local2: Point<N>) {
         if local2 != self.anchor2.position {
             self.up_to_date = false;
             self.anchor2.position = local2
@@ -54,22 +55,22 @@ impl BallInSocket {
 }
 
 
-impl Joint<Point> for BallInSocket {
+impl<N: Scalar> Joint<N, Point<N>> for BallInSocket<N> {
     /// The first anchor affected by this joint.
     #[inline]
-    fn anchor1(&self) -> &Anchor<Point> {
+    fn anchor1(&self) -> &Anchor<N, Point<N>> {
         &self.anchor1
     }
 
     /// The second anchor affected by this joint.
     #[inline]
-    fn anchor2(&self) -> &Anchor<Point> {
+    fn anchor2(&self) -> &Anchor<N, Point<N>> {
         &self.anchor2
     }
 
     /// The first attach point in global coordinates.
     #[inline]
-    fn anchor1_pos(&self) -> Point {
+    fn anchor1_pos(&self) -> Point<N> {
         match self.anchor1.body {
             Some(ref b) => {
                 b.borrow().position().transform(&self.anchor1.position)
@@ -80,7 +81,7 @@ impl Joint<Point> for BallInSocket {
 
     /// The second attach point in global coordinates.
     #[inline]
-    fn anchor2_pos(&self) -> Point {
+    fn anchor2_pos(&self) -> Point<N> {
         match self.anchor2.body {
             Some(ref b) => {
                 b.borrow().position().transform(&self.anchor2.position)

--- a/src/detection/joint/fixed.rs
+++ b/src/detection/joint/fixed.rs
@@ -1,17 +1,18 @@
+use ncollide::math::Scalar;
 use math::Matrix;
 use detection::joint::anchor::Anchor;
 use detection::joint::joint::Joint;
 
 /// A joint that prevents any relative movement (linear and angular) between two objects.
-pub struct Fixed {
+pub struct Fixed<N: Scalar> {
     up_to_date: bool,
-    anchor1:    Anchor<Matrix>,
-    anchor2:    Anchor<Matrix>,
+    anchor1:    Anchor<N, Matrix<N>>,
+    anchor2:    Anchor<N, Matrix<N>>,
 }
 
-impl Fixed {
+impl<N: Scalar> Fixed<N> {
     /// Creates a new `Fixed` joint.
-    pub fn new(anchor1: Anchor<Matrix>, anchor2: Anchor<Matrix>) -> Fixed {
+    pub fn new(anchor1: Anchor<N, Matrix<N>>, anchor2: Anchor<N, Matrix<N>>) -> Fixed<N> {
         Fixed {
             up_to_date: false,
             anchor1:    anchor1,
@@ -32,7 +33,7 @@ impl Fixed {
     /// Sets the the second anchor position.
     ///
     /// The position is expressed in the second attached body’s local coordinates.
-    pub fn set_local1(&mut self, local1: Matrix) {
+    pub fn set_local1(&mut self, local1: Matrix<N>) {
         if local1 != self.anchor1.position {
             self.up_to_date = false;
             self.anchor1.position = local1
@@ -42,7 +43,7 @@ impl Fixed {
     /// Sets the the second anchor position.
     ///
     /// The position is expressed in the second attached body’s local coordinates.
-    pub fn set_local2(&mut self, local2: Matrix) {
+    pub fn set_local2(&mut self, local2: Matrix<N>) {
         if local2 != self.anchor2.position {
             self.up_to_date = false;
             self.anchor2.position = local2
@@ -50,22 +51,22 @@ impl Fixed {
     }
 }
 
-impl Joint<Matrix> for Fixed {
+impl<N: Scalar> Joint<N, Matrix<N>> for Fixed<N> {
     /// The first anchor affected by this joint.
     #[inline]
-    fn anchor1(&self) -> &Anchor<Matrix> {
+    fn anchor1(&self) -> &Anchor<N, Matrix<N>> {
         &self.anchor1
     }
 
     /// The second anchor affected by this joint.
     #[inline]
-    fn anchor2(&self) -> &Anchor<Matrix> {
+    fn anchor2(&self) -> &Anchor<N, Matrix<N>> {
         &self.anchor2
     }
 
     /// The first attach point in global coordinates.
     #[inline]
-    fn anchor1_pos(&self) -> Matrix {
+    fn anchor1_pos(&self) -> Matrix<N> {
         match self.anchor1.body {
             Some(ref b) => {
                 *b.borrow().position() * self.anchor1.position
@@ -76,7 +77,7 @@ impl Joint<Matrix> for Fixed {
 
     /// The second attach point in global coordinates.
     #[inline]
-    fn anchor2_pos(&self) -> Matrix {
+    fn anchor2_pos(&self) -> Matrix<N> {
         match self.anchor2.body {
             Some(ref b) => {
                 *b.borrow().position() * self.anchor2.position

--- a/src/detection/joint/joint.rs
+++ b/src/detection/joint/joint.rs
@@ -1,12 +1,13 @@
+use ncollide::math::Scalar;
 use detection::joint::anchor::Anchor;
 
 // FIXME: this wont be very helpful to mix several joints.
 /// Trait implemented by every joint.
-pub trait Joint<A> {
+pub trait Joint<N: Scalar, A> {
     /// The first anchor affected by this joint.
-    fn anchor1(&self) -> &Anchor<A>;
+    fn anchor1(&self) -> &Anchor<N, A>;
     /// The second anchor affected by this joint.
-    fn anchor2(&self) -> &Anchor<A>;
+    fn anchor2(&self) -> &Anchor<N, A>;
     /// The first attach point in global coordinates.
     fn anchor1_pos(&self) -> A;
     /// The second attach point in global coordinates.

--- a/src/integration/body_damping.rs
+++ b/src/integration/body_damping.rs
@@ -1,6 +1,6 @@
 //! Linear and angular velocity damping.
 
-use math::Scalar;
+use ncollide::math::Scalar;
 use integration::Integrator;
 use object::RigidBody;
 
@@ -8,12 +8,12 @@ use object::RigidBody;
 ///
 /// This will remove a part of the linear and angular velocity of every rigid body at each frame.
 /// Do not use unless you are experiencing unrealistic vibrations or very unstable joints.
-pub struct BodyDamping {
-    linear_damping:  Scalar,
-    angular_damping: Scalar
+pub struct BodyDamping<N: Scalar> {
+    linear_damping:  N,
+    angular_damping: N
 }
 
-impl BodyDamping {
+impl<N: Scalar> BodyDamping<N> {
     /// Creates a new `BodyDamping`.
     ///
     /// # Arguments:
@@ -22,7 +22,7 @@ impl BodyDamping {
     /// * `linear_damping` - coefficient in [0, 1] the angular velocity of each rigid body is
     ///                      multiplied at each update.
     #[inline]
-    pub fn new(linear_damping: Scalar, angular_damping: Scalar) -> BodyDamping {
+    pub fn new(linear_damping: N, angular_damping: N) -> BodyDamping<N> {
         BodyDamping {
             linear_damping:  linear_damping,
             angular_damping: angular_damping,
@@ -30,8 +30,8 @@ impl BodyDamping {
     }
 }
 
-impl Integrator<RigidBody> for BodyDamping {
-    fn update(&mut self, _: Scalar, rb: &mut RigidBody) {
+impl<N: Scalar> Integrator<N, RigidBody<N>> for BodyDamping<N> {
+    fn update(&mut self, _: N, rb: &mut RigidBody<N>) {
         let new_lin = rb.lin_vel() * self.linear_damping;
 
         rb.set_lin_vel(new_lin);

--- a/src/integration/body_exp_euler_integrator.rs
+++ b/src/integration/body_exp_euler_integrator.rs
@@ -1,7 +1,7 @@
 //! Explicit Euler integrator.
 
+use ncollide::math::Scalar;
 use na::Transformation;
-use math::Scalar;
 use object::RigidBody;
 use integration::Integrator;
 use integration::euler;
@@ -19,9 +19,9 @@ impl BodyExpEulerIntegrator {
     }
 }
 
-impl Integrator<RigidBody> for BodyExpEulerIntegrator {
+impl<N: Scalar> Integrator<N, RigidBody<N>> for BodyExpEulerIntegrator {
     #[inline]
-    fn update(&mut self, dt: Scalar, rb: &mut RigidBody) {
+    fn update(&mut self, dt: N, rb: &mut RigidBody<N>) {
         if rb.can_move() {
             let (t, lv, av) = euler::explicit_integrate(
                 dt.clone(),

--- a/src/integration/body_force_generator.rs
+++ b/src/integration/body_force_generator.rs
@@ -1,23 +1,24 @@
 //! Constant linear and angular force generator.
 
-use math::{Scalar, Vect, Orientation};
+use ncollide::math::Scalar;
+use math::{Vector, Orientation};
 use object::RigidBody;
 use integration::Integrator;
 
 /// A constant linear and angular force generator.
-pub struct BodyForceGenerator {
-    lin_acc: Vect,
-    ang_acc: Orientation
+pub struct BodyForceGenerator<N: Scalar> {
+    lin_acc: Vector<N>,
+    ang_acc: Orientation<N>
 }
 
-impl BodyForceGenerator {
+impl<N: Scalar> BodyForceGenerator<N> {
     /// Creates a new `BodyForceGenerator`.
     ///
     /// # Arguments:
     ///
     /// * `lin_acc` - the linear acceleration to apply to every body on the scene.
     /// * `ang_acc` - the angular acceleration to apply to every body on the scene.
-    pub fn new(lin_acc: Vect, ang_acc: Orientation) -> BodyForceGenerator {
+    pub fn new(lin_acc: Vector<N>, ang_acc: Orientation<N>) -> BodyForceGenerator<N> {
         BodyForceGenerator {
             lin_acc: lin_acc,
             ang_acc: ang_acc
@@ -25,35 +26,35 @@ impl BodyForceGenerator {
     }
 }
 
-impl BodyForceGenerator {
+impl<N: Scalar> BodyForceGenerator<N> {
     /// The linear acceleration applied by this force generator.
     #[inline]
-    pub fn lin_acc(&self) -> Vect {
+    pub fn lin_acc(&self) -> Vector<N> {
         self.lin_acc.clone()
     }
 
     /// Sets the linear acceleration applied by this force generator.
     #[inline]
-    pub fn set_lin_acc(&mut self, lin_acc: Vect) {
+    pub fn set_lin_acc(&mut self, lin_acc: Vector<N>) {
         self.lin_acc = lin_acc;
     }
 
     /// The angular acceleration applied by this force generator.
     #[inline]
-    pub fn ang_acc(&self) -> Orientation {
+    pub fn ang_acc(&self) -> Orientation<N> {
         self.ang_acc.clone()
     }
 
     /// Sets the angular acceleration applied by this force generator.
     #[inline]
-    pub fn set_ang_acc(&mut self, ang_acc: Orientation) {
+    pub fn set_ang_acc(&mut self, ang_acc: Orientation<N>) {
         self.ang_acc = ang_acc;
     }
 }
 
-impl Integrator<RigidBody> for BodyForceGenerator {
+impl<N: Scalar> Integrator<N, RigidBody<N>> for BodyForceGenerator<N> {
     #[inline]
-    fn update(&mut self, _: Scalar, rb: &mut RigidBody) {
+    fn update(&mut self, _: N, rb: &mut RigidBody<N>) {
         rb.set_gravity(self.lin_acc.clone());
         //rb.set_ang_acc(self.ang_acc.clone());
     }

--- a/src/integration/body_smp_euler_integrator.rs
+++ b/src/integration/body_smp_euler_integrator.rs
@@ -1,10 +1,10 @@
 //! Semi-implicit Euler integrator.
 
 use na::Transformation;
+use ncollide::math::Scalar;
 use object::RigidBody;
 use integration::Integrator;
 use integration::euler;
-use math::Scalar;
 
 /// A semi-implicit Euler integrator.
 pub struct BodySmpEulerIntegrator;
@@ -17,9 +17,9 @@ impl BodySmpEulerIntegrator {
     }
 }
 
-impl Integrator<RigidBody> for BodySmpEulerIntegrator {
+impl<N: Scalar> Integrator<N, RigidBody<N>> for BodySmpEulerIntegrator {
     #[inline]
-    fn update(&mut self, dt: Scalar, rb: &mut RigidBody) {
+    fn update(&mut self, dt: N, rb: &mut RigidBody<N>) {
         if rb.can_move() {
             let (t, lv, av) = euler::semi_implicit_integrate(
                 dt.clone(),

--- a/src/integration/euler.rs
+++ b/src/integration/euler.rs
@@ -1,11 +1,15 @@
 //! Euler integration functions.
 
-use na::{Translation, RotationWithTranslation};
-use na;
-use math::{Scalar, Point, Vect, Orientation, Matrix};
+use na::{self, Translation, RotationWithTranslation};
+use ncollide::math::Scalar;
+use math::{Point, Vector, Orientation, Matrix};
 
 /// Explicit Euler integrator.
-pub fn explicit_integrate(dt: Scalar, p: &Matrix, c: &Point, lv: &Vect, av: &Orientation, lf: &Vect, af: &Orientation) -> (Matrix, Vect, Orientation) {
+pub fn explicit_integrate<N: Scalar>(dt: N,
+                                     p:  &Matrix<N>, c:  &Point<N>,
+                                     lv: &Vector<N>, av: &Orientation<N>,
+                                     lf: &Vector<N>, af: &Orientation<N>)
+                                     -> (Matrix<N>, Vector<N>, Orientation<N>) {
     (
         displacement(dt.clone(), p, c, lv, av), 
         *lv + *lf * dt,
@@ -14,7 +18,8 @@ pub fn explicit_integrate(dt: Scalar, p: &Matrix, c: &Point, lv: &Vect, av: &Ori
 }
 
 /// Explicit Euler integrator. This will not update the rotational components.
-pub fn explicit_integrate_wo_rotation(dt: Scalar, p: &Point, lv: &Vect, lf: &Vect) -> (Point, Vect) {
+pub fn explicit_integrate_wo_rotation<N: Scalar>(dt: N, p: &Point<N>, lv: &Vector<N>, lf: &Vector<N>)
+                                                 -> (Point<N>, Vector<N>) {
     (
         *p  + *lv * dt, 
         *lv + *lf * dt
@@ -22,7 +27,11 @@ pub fn explicit_integrate_wo_rotation(dt: Scalar, p: &Point, lv: &Vect, lf: &Vec
 }
 
 /// Semi-implicit Euler integrator.
-pub fn semi_implicit_integrate(dt: Scalar, p: &Matrix, c: &Point, lv: &Vect, av: &Orientation, l_acc: &Vect, a_acc: &Orientation) -> (Matrix, Vect, Orientation) {
+pub fn semi_implicit_integrate<N: Scalar>(dt: N,
+                                          p:     &Matrix<N>, c:     &Point<N>,
+                                          lv:    &Vector<N>, av:    &Orientation<N>,
+                                          l_acc: &Vector<N>, a_acc: &Orientation<N>)
+                                          -> (Matrix<N>, Vector<N>, Orientation<N>) {
     let nlv = *lv + *l_acc * dt;
     let nav = *av + *a_acc * dt;
 
@@ -34,7 +43,8 @@ pub fn semi_implicit_integrate(dt: Scalar, p: &Matrix, c: &Point, lv: &Vect, av:
 }
 
 /// Semi-implicit Euler integrator. This will not update the rotational components.
-pub fn semi_implicit_integrate_wo_rotation(dt: Scalar, p: &Point, lv: &Vect, lf: &Vect) -> (Point, Vect) {
+pub fn semi_implicit_integrate_wo_rotation<N: Scalar>(dt: N, p: &Point<N>, lv: &Vector<N>, lf: &Vector<N>)
+                                                      -> (Point<N>, Vector<N>) {
     let nlv = *lv + *lf * dt;
 
     (
@@ -45,8 +55,9 @@ pub fn semi_implicit_integrate_wo_rotation(dt: Scalar, p: &Point, lv: &Vect, lf:
 
 /// Computes the transformation matrix required to move an object with a `lin_vel` linear velocity,
 /// a `ang_vil` angular velocity, and a center of mass `center_of_mass`, during the time step `dt`.
-pub fn displacement(dt: Scalar, _: &Matrix, center_of_mass: &Point, lin_vel: &Vect, ang_vel: &Orientation) -> Matrix {
-    let mut res: Matrix = na::one();
+pub fn displacement<N: Scalar>(dt: N, _: &Matrix<N>, center_of_mass: &Point<N>,
+                               lin_vel: &Vector<N>, ang_vel: &Orientation<N>) -> Matrix<N> {
+    let mut res: Matrix<N> = na::one();
     res.append_rotation_wrt_point_mut(&(*ang_vel * dt), center_of_mass.as_vec());
 
     res.append_translation_mut(&(*lin_vel * dt));

--- a/src/integration/integrator.rs
+++ b/src/integration/integrator.rs
@@ -1,11 +1,11 @@
 //! Trait implemented by every integrators.
 
-use math::Scalar;
+use ncollide::math::Scalar;
 
 /// Trait implemented by every integrator.
 ///
 /// An integrator is a structure capable of updating a dynamic body position and orientation after a given time-step.
-pub trait Integrator<O> {
+pub trait Integrator<N: Scalar, O> {
     /// Updates the position and orientation of the object `o` after a time step of `dt`.
-    fn update(&mut self, dt: Scalar, o: &mut O);
+    fn update(&mut self, dt: N, o: &mut O);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,16 +46,6 @@ For the 3D version, add the crate named `nphysics3d`:
 nphysics3d = "0.1.*"
 ```
 
-By default, 32-bit floating point numbers are used by the library. If you need
-more accuracy, use either version of nphysics with the feature `f64` enabled.
-For example:
-
-```ignore
-[dependencies.nphysics2d]
-version  = "0.1.*"
-features = "f64"
-```
-
 Use `make examples` to build the demos and execute `./your_favorite_example_here --help`
 to see all the cool stuffs you can do.
 
@@ -127,31 +117,23 @@ mod tests;
 pub mod math {
     use na::{Pnt3, Vec3, Mat3, Rot3, Iso3};
 
-    /// The scalar type.
-    #[cfg(all(feature = "f32", not(feature = "f64")))]
-    pub type Scalar = f32;
-
-    /// The scalar type.
-    #[cfg(feature = "f64")]
-    pub type Scalar = f64;
-
     /// The point type.
-    pub type Point = Pnt3<Scalar>;
+    pub type Point<N> = Pnt3<N>;
 
     /// The vector type.
-    pub type Vect = Vec3<Scalar>;
+    pub type Vector<N> = Vec3<N>;
 
     /// The orientation type.
-    pub type Orientation = Vec3<Scalar>;
+    pub type Orientation<N> = Vec3<N>;
 
     /// The transformation matrix type.
-    pub type Matrix = Iso3<Scalar>;
+    pub type Matrix<N> = Iso3<N>;
 
     /// The rotation matrix type.
-    pub type RotationMatrix = Rot3<Scalar>;
+    pub type RotationMatrix<N> = Rot3<N>;
 
     /// The inertia tensor type.
-    pub type AngularInertia = Mat3<Scalar>;
+    pub type AngularInertia<N> = Mat3<N>;
 }
 
 /// Compilation flags dependent aliases for mathematical types.
@@ -159,29 +141,21 @@ pub mod math {
 pub mod math {
     use na::{Pnt2, Vec1, Vec2, Mat1, Rot2, Iso2};
 
-    /// The scalar type.
-    #[cfg(all(feature = "f32", not(feature = "f64")))]
-    pub type Scalar = f32;
-
-    /// The scalar type.
-    #[cfg(feature = "f64")]
-    pub type Scalar = f64;
-
     /// The point type.
-    pub type Point = Pnt2<Scalar>;
+    pub type Point<N> = Pnt2<N>;
 
     /// The vector type.
-    pub type Vect = Vec2<Scalar>;
+    pub type Vector<N> = Vec2<N>;
 
     /// The orientation type.
-    pub type Orientation = Vec1<Scalar>;
+    pub type Orientation<N> = Vec1<N>;
 
     /// The transformation matrix type.
-    pub type Matrix = Iso2<Scalar>;
+    pub type Matrix<N> = Iso2<N>;
 
     /// The rotation matrix type.
-    pub type RotationMatrix = Rot2<Scalar>;
+    pub type RotationMatrix<N> = Rot2<N>;
 
     /// The inertia tensor type.
-    pub type AngularInertia = Mat1<Scalar>;
+    pub type AngularInertia<N> = Mat1<N>;
 }

--- a/src/resolution/constraint/projected_gauss_seidel_solver.rs
+++ b/src/resolution/constraint/projected_gauss_seidel_solver.rs
@@ -1,19 +1,20 @@
 use na;
-use math::{Vect, Orientation};
+use ncollide::math::Scalar;
+use math::{Vector, Orientation};
 use resolution::constraint::velocity_constraint::VelocityConstraint;
 
 /// Structure holding the result of the projected gauss seidel solver.
 #[derive(PartialEq, Debug, Clone)]
-pub struct Velocities {
+pub struct Velocities<N: Scalar> {
     /// Linear velocity.
-    pub lv: Vect,
+    pub lv: Vector<N>,
     /// Angular velocity.
-    pub av: Orientation
+    pub av: Orientation<N>
 }
 
-impl Velocities {
+impl<N: Scalar> Velocities<N> {
     /// Creates a new `Velocities`.
-    pub fn new() -> Velocities {
+    pub fn new() -> Velocities<N> {
         Velocities {
             lv: na::zero(),
             av: na::zero()
@@ -39,12 +40,12 @@ impl Velocities {
 /// * `is_lambda_zero` - indicates whether or not the every element of `result` has been
 /// reinitialized. Set this to `false` if the `result` comes from a previous execution of
 /// `projected_gauss_seidel_solve`: this will perform warm-starting.
-pub fn projected_gauss_seidel_solve(restitution:    &mut [VelocityConstraint],
-                                    friction:       &mut [VelocityConstraint],
-                                    result:         &mut [Velocities],
-                                    num_bodies:     usize,
-                                    num_iterations: usize,
-                                    is_lambda_zero: bool) {
+pub fn projected_gauss_seidel_solve<N: Scalar>(restitution:    &mut [VelocityConstraint<N>],
+                                               friction:       &mut [VelocityConstraint<N>],
+                                               result:         &mut [Velocities<N>],
+                                               num_bodies:     usize,
+                                               num_iterations: usize,
+                                               is_lambda_zero: bool) {
     // initialize the solution with zeros...
     // mj_lambda is result
     assert!(result.len() == num_bodies);
@@ -87,7 +88,7 @@ pub fn projected_gauss_seidel_solve(restitution:    &mut [VelocityConstraint],
 }
 
 #[inline(always)]
-fn setup_warmstart_for_constraint(c: &VelocityConstraint, mj_lambda: &mut [Velocities]) {
+fn setup_warmstart_for_constraint<N: Scalar>(c: &VelocityConstraint<N>, mj_lambda: &mut [Velocities<N>]) {
     let id1 = c.id1;
     let id2 = c.id2;
 
@@ -103,7 +104,7 @@ fn setup_warmstart_for_constraint(c: &VelocityConstraint, mj_lambda: &mut [Veloc
 }
 
 #[inline(always)]
-fn solve_velocity_constraint(c: &mut VelocityConstraint, mj_lambda: &mut [Velocities]) {
+fn solve_velocity_constraint<N: Scalar>(c: &mut VelocityConstraint<N>, mj_lambda: &mut [Velocities<N>]) {
     let id1 = c.id1;
     let id2 = c.id2;
 

--- a/src/resolution/constraint/velocity_constraint.rs
+++ b/src/resolution/constraint/velocity_constraint.rs
@@ -1,38 +1,39 @@
 use na;
-use math::{Scalar, Vect, Orientation};
+use ncollide::math::Scalar;
+use math::{Vector, Orientation};
 
 #[derive(PartialEq, Debug, Clone)]
 /// A constraint of velocity at a point of contact.
-pub struct VelocityConstraint {
+pub struct VelocityConstraint<N: Scalar> {
     /// The contact normal.
-    pub normal:             Vect,
+    pub normal:             Vector<N>,
 
     /// The contact normal multiplied by the first body's inverse mass.
-    pub weighted_normal1:   Vect,
+    pub weighted_normal1:   Vector<N>,
     /// The contact normal multiplied by the second body's inverse mass.
-    pub weighted_normal2:   Vect,
+    pub weighted_normal2:   Vector<N>,
 
     /// The first body rotation axis.
-    pub rot_axis1:          Orientation,
+    pub rot_axis1:          Orientation<N>,
     /// The first body rotation axis multiplied by its inverse inertia.
-    pub weighted_rot_axis1: Orientation,
+    pub weighted_rot_axis1: Orientation<N>,
 
     /// The second body rotation axis.
-    pub rot_axis2:          Orientation,
+    pub rot_axis2:          Orientation<N>,
     /// The second body rotation axis multiplied by its inverse inertia.
-    pub weighted_rot_axis2: Orientation,
+    pub weighted_rot_axis2: Orientation<N>,
 
     /// The inverse of the sum of linear and angular inertia of both bodies.
-    pub inv_projected_mass: Scalar,
+    pub inv_projected_mass: N,
 
     /// The total impulse applied.
-    pub impulse:            Scalar,
+    pub impulse:            N,
     /// The lower bound of the impulse.
-    pub lobound:            Scalar,
+    pub lobound:            N,
     /// The upper bound of the impulse.
-    pub hibound:            Scalar,
+    pub hibound:            N,
     /// The target delta velocity.
-    pub objective:          Scalar,
+    pub objective:          N,
     /// The id of the first body.
     pub id1:                isize,
     /// The id of the second body.
@@ -40,12 +41,12 @@ pub struct VelocityConstraint {
     /// The id of the friction constraint.
     pub friction_limit_id:  usize,
     /// The friction coefficient on this contact.
-    pub friction_coeff:     Scalar
+    pub friction_coeff:     N
 }
 
-impl VelocityConstraint {
+impl<N: Scalar> VelocityConstraint<N> {
     /// Creates a new velocity constraint with all terms initialized to zero.
-    pub fn new() -> VelocityConstraint {
+    pub fn new() -> VelocityConstraint<N> {
         VelocityConstraint {
             normal:             na::zero(),
 

--- a/src/resolution/solver.rs
+++ b/src/resolution/solver.rs
@@ -1,7 +1,7 @@
-use math::Scalar;
+use na::BaseFloat;
 
 /// Trait implemented by constraint solvers.
-pub trait Solver<I> {
+pub trait Solver<N: BaseFloat, I> {
     /// Solve the set of constraints of type `I`.
-    fn solve(&mut self, Scalar, &[I]);
+    fn solve(&mut self, N, &[I]);
 }


### PR DESCRIPTION
As discussed in #53 cargo features should be additive, so using them as we do en `nphysics` might cause compilation-error related headaches for the user in case of simultaneous dependencies to, e.g., `nphysics2d` twice, once with and once without the `f64` feature enabled. The simplest and most idiomatic fix here is to make everything generic wrt. the scalar type.

Fix #53.