### PR TITLE
Add sensors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ This project adheres to [Semantic Versioning](http://semver.org/).
     rigid bodies with CCD should trigger events for sensors it should have
     traversed.
   * `World::interferences()` has been renamed to `World::constraints()`.
+  * `Volumetric::surface()` has been renamed to `Volumetric::area()`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Change Log
+All notable changes to `nalgebra`, starting with the version 0.6.0 will be
+documented here.
+
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.3.0]
+### Added
+  * Added sensors.
+
+### Modified
+  * `World::add_body` and `World::remove_body` have been renamed to
+    `World::add_rigid_body` and `World::remove_rigid_body`.
+  * `World::add_ccd_to(...)` has an additional argument indicating whether
+    rigid bodies with CCD should trigger events for sensors it should have
+    traversed.
+  * `World::interferences()` has been renamed to `World::constraints()`.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ to see all the cool stuffs you can do.
 - Swept sphere based continuous collision detection.
 - Ball-in-socket joint.
 - Fixed joint.
+- Sensors.
 
 ## What is missing?
 **nphysics** is a very young library and needs to learn a lot of things to

--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -21,5 +21,5 @@ path = "../../src/lib.rs"
 [dependencies]
 rustc-serialize = "0.3.*"
 num  = "0.1.*"
-nalgebra = "0.6.*"
-ncollide = "0.7.*"
+nalgebra = "0.8.*"
+ncollide = "0.8.*"

--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nphysics2d"
-version = "0.2.2"
+version = "0.3.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "2-dimensional physics engine in Rust."
 documentation = "http://nphysics.org/doc/nphysics2d"

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -21,5 +21,5 @@ path = "../../src/lib.rs"
 [dependencies]
 rustc-serialize = "0.3.*"
 num  = "0.1.*"
-nalgebra = "0.6.*"
-ncollide = "0.7.*"
+nalgebra = "0.8.*"
+ncollide = "0.8.*"

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "nphysics3d"
-version = "0.2.2"
+version = "0.3.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 description = "3-dimensional physics engine in Rust."
 documentation = "http://nphysics.org/doc/nphysics3d"

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -64,5 +64,9 @@ name = "manual_forces"
 path = "./manual_forces.rs"
 
 [[bin]]
+name = "collision_groups"
+path = "./collision_groups.rs"
+
+[[bin]]
 name = "sensor"
 path = "./sensor.rs"

--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -62,3 +62,7 @@ path = "./fixed_bug_11.rs"
 [[bin]]
 name = "manual_forces"
 path = "./manual_forces.rs"
+
+[[bin]]
+name = "sensor"
+path = "./sensor.rs"

--- a/examples2d/balls_vee.rs
+++ b/examples2d/balls_vee.rs
@@ -5,7 +5,7 @@ extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
 use num::Float;
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::{Ball, Plane};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -21,7 +21,7 @@ fn main() {
 
 fn create_the_world() -> World<f32> {
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
     world
 }
 
@@ -30,15 +30,15 @@ fn create_the_walls(world: &mut World<f32>) {
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
+    rb.append_translation(&Vector2::new(0.0, 10.0));
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
+    rb.append_translation(&Vector2::new(0.0, 10.0));
     world.add_rigid_body(rb);
 }
 
@@ -57,7 +57,7 @@ fn create_the_balls(world: &mut World<f32>) {
 
             let mut rb = RigidBody::new_dynamic(Ball::new(rad), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/balls_vee.rs
+++ b/examples2d/balls_vee.rs
@@ -32,14 +32,14 @@ fn create_the_walls(world: &mut World<f32>) {
      */
     let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
     rb.append_translation(&Vec2::new(0.0, 10.0));
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
     let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
     rb.append_translation(&Vec2::new(0.0, 10.0));
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 }
 
 
@@ -59,7 +59,7 @@ fn create_the_balls(world: &mut World<f32>) {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 }

--- a/examples2d/boxes_vee.rs
+++ b/examples2d/boxes_vee.rs
@@ -25,7 +25,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -34,7 +34,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -55,7 +55,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/boxes_vee.rs
+++ b/examples2d/boxes_vee.rs
@@ -5,7 +5,7 @@ extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
 use num::Float;
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -16,23 +16,23 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
@@ -50,10 +50,10 @@ fn main() {
             let x = i as f32 * 2.5 * rad - centerx;
             let y = j as f32 * 2.5 * rad - centery * 2.0 - 10.0;
 
-            let geom   = Cuboid::new(Vec2::new(rad, rad));
+            let geom   = Cuboid::new(Vector2::new(rad, rad));
             let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/collision_groups.rs
+++ b/examples2d/collision_groups.rs
@@ -1,0 +1,111 @@
+extern crate nalgebra as na;
+extern crate ncollide;
+extern crate nphysics2d;
+extern crate nphysics_testbed2d;
+
+use na::{Pnt3, Vec2, Translation};
+use ncollide::shape::{Plane, Cuboid};
+use nphysics2d::world::World;
+use nphysics2d::object::{RigidBody, RigidBodyCollisionGroups};
+use nphysics_testbed2d::Testbed;
+
+fn main() {
+    let mut testbed = Testbed::new_empty();
+
+    /*
+     * World
+     */
+    let mut world = World::new();
+    world.set_gravity(Vec2::new(0.0, 9.81));
+
+    /*
+     * Declare groups.
+     */
+    const GREEN_GROUP_ID: usize = 0;
+    let mut green_static_group  = RigidBodyCollisionGroups::new_static();
+    green_static_group.set_membership(&[ GREEN_GROUP_ID ]);
+    green_static_group.set_whitelist(&[ GREEN_GROUP_ID ]);
+
+    let mut green_dynamic_group = RigidBodyCollisionGroups::new_dynamic();
+    green_dynamic_group.set_membership(&[ GREEN_GROUP_ID ]);
+    green_dynamic_group.set_whitelist(&[ GREEN_GROUP_ID ]);
+
+
+    const BLUE_GROUP_ID: usize = 1;
+    let mut blue_static_group = RigidBodyCollisionGroups::new_static();
+    blue_static_group.set_membership(&[ BLUE_GROUP_ID ]);
+    blue_static_group.set_whitelist(&[ BLUE_GROUP_ID ]);
+
+    let mut blue_dynamic_group = RigidBodyCollisionGroups::new_dynamic();
+    blue_dynamic_group.set_membership(&[ BLUE_GROUP_ID ]);
+    blue_dynamic_group.set_whitelist(&[ BLUE_GROUP_ID ]);
+
+    /*
+     * A floor that will collide with everything (default behaviour).
+     */
+    let geom = Plane::new(Vec2::new(0.0, -1.0));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
+
+    /*
+     * A green floor that will collide with the BLUE group only.
+     */
+    let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
+    let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
+
+    rb.set_collision_groups(green_static_group);
+    rb.append_translation(&Vec2::new(0.0, -5.0));
+
+    let handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+
+    /*
+     * A blue floor that will collide with the GREEN group only.
+     */
+    let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
+    let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
+
+    rb.set_collision_groups(blue_static_group);
+    rb.append_translation(&Vec2::new(0.0, -10.0));
+
+    let handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+
+    /*
+     * Create the boxes
+     */
+    let num     = 8;
+    let rad     = 1.0;
+    let shift   = rad * 2.0;
+    let centerx = shift * (num as f32) / 2.0;
+    let centery = 25.0;
+
+    for k in 0usize .. 4 {
+        for i in 0usize .. num {
+            let x = i as f32 * shift - centerx;
+            let y = k as f32 * shift + centery;
+
+            let geom   = Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04));
+            let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
+
+            rb.append_translation(&Vec2::new(x, -y));
+
+            // Alternate between the GREEN and BLUE groups.
+            if k % 2 == 0 {
+                rb.set_collision_groups(green_dynamic_group);
+                let handle = world.add_rigid_body(rb);
+                testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+            }
+            else {
+                rb.set_collision_groups(blue_dynamic_group);
+                let handle = world.add_rigid_body(rb);
+                testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(world);
+    testbed.run();
+}

--- a/examples2d/collision_groups.rs
+++ b/examples2d/collision_groups.rs
@@ -19,7 +19,7 @@ fn main() {
     world.set_gravity(Vec2::new(0.0, 9.81));
 
     /*
-     * Declare groups.
+     * Setup groups.
      */
     const GREEN_GROUP_ID: usize = 0;
     let mut green_static_group  = RigidBodyCollisionGroups::new_static();
@@ -47,7 +47,7 @@ fn main() {
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
-     * A green floor that will collide with the BLUE group only.
+     * A green floor that will collide with the GREEN group only.
      */
     let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
@@ -59,7 +59,7 @@ fn main() {
     testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
 
     /*
-     * A blue floor that will collide with the GREEN group only.
+     * A blue floor that will collide with the BLUE group only.
      */
     let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);

--- a/examples2d/collision_groups.rs
+++ b/examples2d/collision_groups.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Pnt3, Vec2, Translation};
+use na::{Point3, Vector2, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics2d::world::World;
 use nphysics2d::object::{RigidBody, RigidBodyCollisionGroups};
@@ -16,7 +16,7 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * Setup groups.
@@ -43,32 +43,32 @@ fn main() {
     /*
      * A floor that will collide with everything (default behaviour).
      */
-    let geom = Plane::new(Vec2::new(0.0, -1.0));
+    let geom = Plane::new(Vector2::new(0.0, -1.0));
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * A green floor that will collide with the GREEN group only.
      */
-    let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
+    let geom   = Cuboid::new(Vector2::new(10.0, 1.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
     rb.set_collision_groups(green_static_group);
-    rb.append_translation(&Vec2::new(0.0, -5.0));
+    rb.append_translation(&Vector2::new(0.0, -5.0));
 
     let handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 1.0, 0.0));
 
     /*
      * A blue floor that will collide with the BLUE group only.
      */
-    let geom   = Cuboid::new(Vec2::new(10.0, 1.0));
+    let geom   = Cuboid::new(Vector2::new(10.0, 1.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
     rb.set_collision_groups(blue_static_group);
-    rb.append_translation(&Vec2::new(0.0, -10.0));
+    rb.append_translation(&Vector2::new(0.0, -10.0));
 
     let handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 0.0, 1.0));
 
     /*
      * Create the boxes
@@ -84,21 +84,21 @@ fn main() {
             let x = i as f32 * shift - centerx;
             let y = k as f32 * shift + centery;
 
-            let geom   = Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04));
+            let geom   = Cuboid::new(Vector2::new(rad - 0.04, rad - 0.04));
             let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-            rb.append_translation(&Vec2::new(x, -y));
+            rb.append_translation(&Vector2::new(x, -y));
 
             // Alternate between the GREEN and BLUE groups.
             if k % 2 == 0 {
                 rb.set_collision_groups(green_dynamic_group);
                 let handle = world.add_rigid_body(rb);
-                testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+                testbed.set_rigid_body_color(&handle, Point3::new(0.0, 1.0, 0.0));
             }
             else {
                 rb.set_collision_groups(blue_dynamic_group);
                 let handle = world.add_rigid_body(rb);
-                testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+                testbed.set_rigid_body_color(&handle, Point3::new(0.0, 0.0, 1.0));
             }
         }
     }

--- a/examples2d/compound.rs
+++ b/examples2d/compound.rs
@@ -28,7 +28,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -37,7 +37,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
@@ -75,7 +75,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/compound.rs
+++ b/examples2d/compound.rs
@@ -5,7 +5,7 @@ extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
 use num::Float;
-use na::{Vec2, Iso2, Translation};
+use na::{Vector2, Isometry2, Translation};
 use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics2d::volumetric::Volumetric;
 use nphysics2d::world::World;
@@ -17,36 +17,36 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
      */
-    let delta1 = Iso2::new(Vec2::new(0.0, -5.0), na::zero());
-    let delta2 = Iso2::new(Vec2::new(-5.0, 0.0), na::zero());
-    let delta3 = Iso2::new(Vec2::new(5.0,  0.0), na::zero());
+    let delta1 = Isometry2::new(Vector2::new(0.0, -5.0), na::zero());
+    let delta2 = Isometry2::new(Vector2::new(-5.0, 0.0), na::zero());
+    let delta3 = Isometry2::new(Vector2::new(5.0,  0.0), na::zero());
 
     let mut cross_geoms = Vec::new();
-    let vertical   = ShapeHandle::new(Cuboid::new(Vec2::new(0.21f32, 4.96)));
-    let horizontal = ShapeHandle::new(Cuboid::new(Vec2::new(4.96f32, 0.21)));
+    let vertical   = ShapeHandle::new(Cuboid::new(Vector2::new(0.21f32, 4.96)));
+    let horizontal = ShapeHandle::new(Cuboid::new(Vector2::new(4.96f32, 0.21)));
     cross_geoms.push((delta1, horizontal));
     cross_geoms.push((delta2, vertical.clone()));
     cross_geoms.push((delta3, vertical));
@@ -71,7 +71,7 @@ fn main() {
 
             let mut rb = RigidBody::new(cross.clone(), Some(mass), 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/compound.rs
+++ b/examples2d/compound.rs
@@ -4,11 +4,9 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use std::sync::Arc;
 use num::Float;
 use na::{Vec2, Iso2, Translation};
-use ncollide::shape::{Plane, Cuboid, Compound};
-use ncollide::inspection::Repr2;
+use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics2d::volumetric::Volumetric;
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -47,15 +45,15 @@ fn main() {
     let delta3 = Iso2::new(Vec2::new(5.0,  0.0), na::zero());
 
     let mut cross_geoms = Vec::new();
-    let vertical   = Arc::new(Box::new(Cuboid::new(Vec2::new(0.21f32, 4.96))) as Box<Repr2<f32>>);
-    let horizontal = Arc::new(Box::new(Cuboid::new(Vec2::new(4.96f32, 0.21))) as Box<Repr2<f32>>);
+    let vertical   = ShapeHandle::new(Cuboid::new(Vec2::new(0.21f32, 4.96)));
+    let horizontal = ShapeHandle::new(Cuboid::new(Vec2::new(4.96f32, 0.21)));
     cross_geoms.push((delta1, horizontal));
     cross_geoms.push((delta2, vertical.clone()));
     cross_geoms.push((delta3, vertical));
 
     let compound = Compound::new(cross_geoms);
     let mass     = compound.mass_properties(1.0);
-    let cross    = Arc::new(Box::new(compound) as Box<Repr2<f32>>);
+    let cross    = ShapeHandle::new(compound);
 
     /*
      * Create the boxes

--- a/examples2d/convex_vee.rs
+++ b/examples2d/convex_vee.rs
@@ -1,12 +1,14 @@
+extern crate rand;
 extern crate num;
 extern crate nalgebra as na;
 extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
+use rand::random;
 use num::Float;
-use na::{Vec2, Pnt2, Translation};
-use ncollide::shape::{Plane, Convex2};
+use na::{Vector2, Point2, Translation};
+use ncollide::shape::{Plane, ConvexHull};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
 use nphysics_testbed2d::Testbed;
@@ -16,31 +18,32 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Create the convex shapes
      */
+    let npts = 10usize;
     let num = (1000.0f32.sqrt()) as usize;
-    let rad = 0.5;
+    let rad = 1.0;
     let shift   = 2.5 * rad;
     let centerx = shift * (num as f32) / 2.0;
     let centery = shift * (num as f32) / 2.0;
@@ -48,14 +51,17 @@ fn main() {
     for i in 0usize .. num {
         for j in 0usize .. num {
             let x = i as f32 * 2.5 * rad - centerx;
-            let y = j as f32 * 2.5 * rad - centery * 2.0 - 10.0;
-            let geom = {
-		let points = vec![Pnt2::new(0.0,  1.0)*rad, Pnt2::new(-0.5, -0.7)*rad,
-				  Pnt2::new(0.0, -1.0)*rad, Pnt2::new( 0.5, -0.7)*rad ];
-		Convex2::new( points )
-	    };
+            let y = j as f32 * 2.5 * rad - centery * 2.0 - 25.0;
+
+            let mut pts = Vec::with_capacity(npts);
+
+            for _ in 0 .. npts {
+                pts.push(random::<Point2<f32>>() * 2.0 + Vector2::new(5.0, 5.0));
+            }
+
+            let geom = ConvexHull::new(pts);
             let mut rb = RigidBody::new_dynamic(geom, 0.1, 0.3, 0.6);
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
             world.add_rigid_body(rb);
         }
     }

--- a/examples2d/convex_vee.rs
+++ b/examples2d/convex_vee.rs
@@ -25,7 +25,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -34,7 +34,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the convex shapes
@@ -56,7 +56,7 @@ fn main() {
 	    };
             let mut rb = RigidBody::new_dynamic(geom, 0.1, 0.3, 0.6);
             rb.append_translation(&Vec2::new(x, y));
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/cross.rs
+++ b/examples2d/cross.rs
@@ -5,10 +5,8 @@ extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
 use num::Float;
-use std::sync::Arc;
 use na::{Vec2, Translation};
-use ncollide::shape::{Plane, Cuboid, Compound};
-use ncollide::inspection::Repr2;
+use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics2d::volumetric::Volumetric;
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -44,15 +42,15 @@ fn main() {
      */
     let mut cross_geoms = Vec::new();
 
-    let edge_x = Box::new(Cuboid::new(Vec2::new(4.96f32, 0.21)));
-    let edge_y = Box::new(Cuboid::new(Vec2::new(0.21f32, 4.96)));
+    let edge_x = Cuboid::new(Vec2::new(4.96f32, 0.21));
+    let edge_y = Cuboid::new(Vec2::new(0.21f32, 4.96));
 
-    cross_geoms.push((na::one(), Arc::new(edge_x as Box<Repr2<f32>>)));
-    cross_geoms.push((na::one(), Arc::new(edge_y as Box<Repr2<f32>>)));
+    cross_geoms.push((na::one(), ShapeHandle::new(edge_x)));
+    cross_geoms.push((na::one(), ShapeHandle::new(edge_y)));
 
     let compound = Compound::new(cross_geoms);
-    let mass = compound.mass_properties(1.0);
-    let cross = Arc::new(Box::new(compound) as Box<Repr2<f32>>);
+    let mass     = compound.mass_properties(1.0);
+    let cross    = ShapeHandle::new(compound);
 
     /*
      * Create the boxes

--- a/examples2d/cross.rs
+++ b/examples2d/cross.rs
@@ -28,7 +28,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -37,7 +37,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
@@ -72,7 +72,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/cross.rs
+++ b/examples2d/cross.rs
@@ -5,7 +5,7 @@ extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
 use num::Float;
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics2d::volumetric::Volumetric;
 use nphysics2d::world::World;
@@ -17,23 +17,23 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
@@ -42,8 +42,8 @@ fn main() {
      */
     let mut cross_geoms = Vec::new();
 
-    let edge_x = Cuboid::new(Vec2::new(4.96f32, 0.21));
-    let edge_y = Cuboid::new(Vec2::new(0.21f32, 4.96));
+    let edge_x = Cuboid::new(Vector2::new(4.96f32, 0.21));
+    let edge_y = Cuboid::new(Vector2::new(0.21f32, 4.96));
 
     cross_geoms.push((na::one(), ShapeHandle::new(edge_x)));
     cross_geoms.push((na::one(), ShapeHandle::new(edge_y)));
@@ -68,7 +68,7 @@ fn main() {
 
             let mut rb = RigidBody::new(cross.clone(), Some(mass), 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/fixed_bug_11.rs
+++ b/examples2d/fixed_bug_11.rs
@@ -22,7 +22,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::Cuboid;
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -33,16 +33,16 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 0.0));
+    world.set_gravity(Vector2::new(0.0, 0.0));
 
     /*
      * Create the box that will be deactivated.
      */
     let rad    = 1.0;
-    let geom   = Cuboid::new(Vec2::new(rad, rad));
+    let geom   = Cuboid::new(Vector2::new(rad, rad));
     let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-    rb.set_lin_vel(Vec2::new(0.99, 0.0));
+    rb.set_lin_vel(Vector2::new(0.99, 0.0));
 
     world.add_rigid_body(rb.clone());
 
@@ -50,7 +50,7 @@ fn main() {
      * Create the box that will not be deactivated.
      */
     rb.set_deactivation_threshold(Some(0.5));
-    rb.append_translation(&Vec2::new(0.0, 3.0));
+    rb.append_translation(&Vector2::new(0.0, 3.0));
 
     world.add_rigid_body(rb);
 

--- a/examples2d/fixed_bug_11.rs
+++ b/examples2d/fixed_bug_11.rs
@@ -44,7 +44,7 @@ fn main() {
 
     rb.set_lin_vel(Vec2::new(0.99, 0.0));
 
-    world.add_body(rb.clone());
+    world.add_rigid_body(rb.clone());
 
     /*
      * Create the box that will not be deactivated.
@@ -52,7 +52,7 @@ fn main() {
     rb.set_deactivation_threshold(Some(0.5));
     rb.append_translation(&Vec2::new(0.0, 3.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Set up the testbed.

--- a/examples2d/gravity.rs
+++ b/examples2d/gravity.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Vec2, Pnt3, Translation};
+use na::{Vector2, Point3, Translation};
 use ncollide::shape::{Ball, Plane};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -16,23 +16,23 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, 1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(0.0, 1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, -10.0));
+    rb.append_translation(&Vector2::new(0.0, -10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(0.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
@@ -52,19 +52,19 @@ fn main() {
 
             let mut rb = RigidBody::new_dynamic(Ball::new(rad), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             let color;
 
             if j == 0 {
                 // Invert the gravity for the blue balls.
-                rb.set_lin_acc_scale(Vec2::new(0.0, -1.0));
-                color = Pnt3::new(0.0, 0.0, 1.0);
+                rb.set_lin_acc_scale(Vector2::new(0.0, -1.0));
+                color = Point3::new(0.0, 0.0, 1.0);
             }
             else {
                 // Double the gravity for the green balls.
-                rb.set_lin_acc_scale(Vec2::new(0.0, 2.0));
-                color = Pnt3::new(0.0, 1.0, 0.0);
+                rb.set_lin_acc_scale(Vector2::new(0.0, 2.0));
+                color = Point3::new(0.0, 1.0, 0.0);
             }
 
             let body = world.add_rigid_body(rb);

--- a/examples2d/gravity.rs
+++ b/examples2d/gravity.rs
@@ -25,7 +25,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, -10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -34,7 +34,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the balls
@@ -67,8 +67,8 @@ fn main() {
                 color = Pnt3::new(0.0, 1.0, 0.0);
             }
 
-            let body = world.add_body(rb);
-            testbed.set_color(&body, color);
+            let body = world.add_rigid_body(rb);
+            testbed.set_rigid_body_color(&body, color);
         }
     }
 

--- a/examples2d/gravity.rs
+++ b/examples2d/gravity.rs
@@ -57,12 +57,12 @@ fn main() {
             let color;
 
             if j == 0 {
-                // invert the gravity for the blue balls.
+                // Invert the gravity for the blue balls.
                 rb.set_lin_acc_scale(Vec2::new(0.0, -1.0));
                 color = Pnt3::new(0.0, 0.0, 1.0);
             }
             else {
-                // double the gravity for the green balls.
+                // Double the gravity for the green balls.
                 rb.set_lin_acc_scale(Vec2::new(0.0, 2.0));
                 color = Pnt3::new(0.0, 1.0, 0.0);
             }

--- a/examples2d/manual_forces.rs
+++ b/examples2d/manual_forces.rs
@@ -28,7 +28,7 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Second plane
@@ -37,8 +37,8 @@ fn main() {
 
     rb.append_translation(&Vec2::new(0.0, 10.0));
 
-    world.add_body(rb);
-
+    world.add_rigid_body(rb);
+    
     /*
      * Create the convex shapes
      */
@@ -72,8 +72,8 @@ fn main() {
             };
             let mut rb = RigidBody::new_dynamic(geom, 0.1, 0.3, 0.6);
             rb.append_translation(&Vec2::new(x, y));
-            let rb_handle = world.add_body(rb);
-
+            let rb_handle = world.add_rigid_body(rb);
+            
             handles.push(rb_handle);
             forces.push(Vec2::new(posneg.ind_sample(&mut rng)*0.00008, pos.ind_sample(&mut rng)*-0.0008));
             ang_forces.push(Vec1::new(pos.ind_sample(&mut rng)*0.001 *wc.ind_sample(&mut rng)));

--- a/examples2d/manual_forces.rs
+++ b/examples2d/manual_forces.rs
@@ -6,8 +6,8 @@ extern crate nphysics_testbed2d;
 extern crate rand;
 
 use num::Float;
-use na::{Vec1, Vec2, Pnt2, Translation};
-use ncollide::shape::{Plane, Convex2};
+use na::{Vector1, Vector2, Translation};
+use ncollide::shape::{Plane, Cuboid};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
 use nphysics_testbed2d::Testbed;
@@ -19,23 +19,23 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(-1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(-1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
 
     /*
      * Second plane
      */
-    let mut rb = RigidBody::new_static(Plane::new(Vec2::new(1.0, -1.0)), 0.3, 0.6);
+    let mut rb = RigidBody::new_static(Plane::new(Vector2::new(1.0, -1.0)), 0.3, 0.6);
 
-    rb.append_translation(&Vec2::new(0.0, 10.0));
+    rb.append_translation(&Vector2::new(0.0, 10.0));
 
     world.add_rigid_body(rb);
     
@@ -65,20 +65,17 @@ fn main() {
         for j in 0usize .. num {
             let x = i as f32 * shift - centerx;
             let y = j as f32 * shift - centery * 2.0 - 10.0;
-            let geom = {
-                let points = vec![Pnt2::new(0.0,  1.0)*rad, Pnt2::new(-0.5, -0.7)*rad,
-                Pnt2::new(0.0, -1.0)*rad, Pnt2::new( 0.5, -0.7)*rad ];
-                Convex2::new( points )
-            };
+
+            let geom = Cuboid::new(Vector2::new(0.5, 0.5));
             let mut rb = RigidBody::new_dynamic(geom, 0.1, 0.3, 0.6);
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
             let rb_handle = world.add_rigid_body(rb);
             
             handles.push(rb_handle);
-            forces.push(Vec2::new(posneg.ind_sample(&mut rng)*0.00008, pos.ind_sample(&mut rng)*-0.0008));
-            ang_forces.push(Vec1::new(pos.ind_sample(&mut rng)*0.001 *wc.ind_sample(&mut rng)));
-            impulses.push(Vec2::new(posneg.ind_sample(&mut rng)*0.1, pos.ind_sample(&mut rng)*-1.0));
-            torques.push(Vec1::new(posneg.ind_sample(&mut rng)*0.1));
+            forces.push(Vector2::new(posneg.ind_sample(&mut rng) * 0.00008, pos.ind_sample(&mut rng) * -0.0008));
+            ang_forces.push(Vector1::new(pos.ind_sample(&mut rng) * 0.001 * wc.ind_sample(&mut rng)));
+            impulses.push(Vector2::new(posneg.ind_sample(&mut rng) * 0.1, pos.ind_sample(&mut rng) * -1.0));
+            torques.push(Vector1::new(posneg.ind_sample(&mut rng) * 0.1));
         }
     }
 
@@ -134,7 +131,7 @@ fn main() {
                         |(object, force)| {
                             let mut obj = object.borrow_mut();
                             let thr = obj.deactivation_threshold().unwrap_or(0.0);
-                            obj.activate(thr*4.0);
+                            obj.activate(thr * 4.0);
                             obj.append_ang_force(force.clone());
                         }
                         ).last();

--- a/examples2d/mesh.rs
+++ b/examples2d/mesh.rs
@@ -8,7 +8,7 @@ extern crate nphysics_testbed2d;
 use std::sync::Arc;
 use num::Float;
 use rand::{StdRng, SeedableRng, Rng};
-use na::{Pnt2, Vec2, Translation};
+use na::{Point2, Vector2, Translation};
 use ncollide::shape::{Cuboid, Polyline};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -19,7 +19,7 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * Polyline
@@ -29,7 +29,7 @@ fn main() {
     let max_h     = 15.0;
     let begin_h   = 15.0;
     let step      = (begin.abs() * 2.0) / (num_split as f32);
-    let mut vertices: Vec<Pnt2<f32>> = (0 .. num_split + 2).map(|i| Pnt2::new(begin + (i as f32) * step, 0.0)).collect();
+    let mut vertices: Vec<Point2<f32>> = (0 .. num_split + 2).map(|i| Point2::new(begin + (i as f32) * step, 0.0)).collect();
     let mut indices  = Vec::new();
     let mut rng: StdRng = SeedableRng::from_seed(&[1, 2, 3, 4][..]);
 
@@ -37,9 +37,9 @@ fn main() {
         let h: f32 = rng.gen();
         vertices[i + 1].y = begin_h - h * max_h;
 
-        indices.push(Pnt2::new(i, i + 1));
+        indices.push(Point2::new(i, i + 1));
     }
-    indices.push(Pnt2::new(num_split, num_split + 1));
+    indices.push(Point2::new(num_split, num_split + 1));
 
     let mesh = Polyline::new(Arc::new(vertices), Arc::new(indices), None, None);
     let rb = RigidBody::new_static(mesh, 0.3, 0.6);
@@ -62,9 +62,9 @@ fn main() {
             let x = fj * 2.0 * rad - centerx;
             let y = -fi * 2.0 * rad;
 
-            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec2::new(rad, rad)), 1.0, 0.3, 0.6);
+            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector2::new(rad, rad)), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/mesh.rs
+++ b/examples2d/mesh.rs
@@ -44,7 +44,7 @@ fn main() {
     let mesh = Polyline::new(Arc::new(vertices), Arc::new(indices), None, None);
     let rb = RigidBody::new_static(mesh, 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -66,7 +66,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/nphysics_testbed2d/Cargo.toml
+++ b/examples2d/nphysics_testbed2d/Cargo.toml
@@ -10,7 +10,7 @@ name = "nphysics_testbed2d"
 path = "../../build/nphysics2d"
 
 [dependencies]
-sfml = "0.9.*"
+sfml = "0.11.*"
 nalgebra = "0.6.*"
 time = "*"
 num = "*"

--- a/examples2d/nphysics_testbed2d/Cargo.toml
+++ b/examples2d/nphysics_testbed2d/Cargo.toml
@@ -11,7 +11,7 @@ path = "../../build/nphysics2d"
 
 [dependencies]
 sfml = "0.11.*"
-nalgebra = "0.6.*"
+nalgebra = "0.8.*"
 time = "*"
 num = "*"
 rand = "*"

--- a/examples2d/nphysics_testbed2d/src/draw_helper.rs
+++ b/examples2d/nphysics_testbed2d/src/draw_helper.rs
@@ -2,7 +2,7 @@ use sfml::graphics;
 use sfml::graphics::{Vertex, VertexArray, Color, RenderTarget};
 use sfml::system::Vector2f;
 use na::Translate;
-use na::Pnt2;
+use na::Point2;
 use na;
 use nphysics2d::world::World;
 use nphysics2d::detection::constraint::Constraint;
@@ -50,8 +50,8 @@ pub fn draw_colls(window:  &mut graphics::RenderWindow,
             Constraint::Fixed(ref bis) => {
                 draw_line(
                     window,
-                    &na::translation(&bis.borrow().anchor1_pos()).translate(&na::orig()),
-                    &na::translation(&bis.borrow().anchor2_pos()).translate(&na::orig()),
+                    &na::translation(&bis.borrow().anchor1_pos()).translate(&na::origin()),
+                    &na::translation(&bis.borrow().anchor2_pos()).translate(&na::origin()),
                     &Color::new_rgb(255, 0, 0)
                 );
             }
@@ -59,7 +59,7 @@ pub fn draw_colls(window:  &mut graphics::RenderWindow,
     }
 }
 
-pub fn draw_line(window: &mut graphics::RenderWindow, v1: &Pnt2<f32>, v2: &Pnt2<f32>, color: &Color) {
+pub fn draw_line(window: &mut graphics::RenderWindow, v1: &Point2<f32>, v2: &Point2<f32>, color: &Color) {
     let mut vertices = VertexArray::new().unwrap();
 
     vertices.append(&Vertex::new(

--- a/examples2d/nphysics_testbed2d/src/draw_helper.rs
+++ b/examples2d/nphysics_testbed2d/src/draw_helper.rs
@@ -1,6 +1,6 @@
 use sfml::graphics;
 use sfml::graphics::{Vertex, VertexArray, Color, RenderTarget};
-use sfml::system::vector2::Vector2f;
+use sfml::system::Vector2f;
 use na::Translate;
 use na::Pnt2;
 use na;
@@ -15,7 +15,7 @@ pub fn draw_colls(window:  &mut graphics::RenderWindow,
 
     let mut collisions = Vec::new();
 
-    physics.interferences(&mut collisions);
+    physics.constraints(&mut collisions);
 
     for c in collisions.iter() {
         match *c {

--- a/examples2d/nphysics_testbed2d/src/engine.rs
+++ b/examples2d/nphysics_testbed2d/src/engine.rs
@@ -38,7 +38,7 @@ impl<'a> GraphicsManager<'a> {
             let bobject = object.borrow();
             let mut nodes = Vec::new();
 
-            self.add_shape(object.clone(), na::one(), bobject.shape_ref(), &mut nodes);
+            self.add_shape(object.clone(), na::one(), bobject.shape().as_ref(), &mut nodes);
 
             nodes
         };
@@ -83,7 +83,7 @@ impl<'a> GraphicsManager<'a> {
         }
         else if let Some(s) = repr.downcast_ref::<Cm>() {
             for &(t, ref s) in s.shapes().iter() {
-                self.add_shape(object.clone(), delta * t, &***s, out)
+                self.add_shape(object.clone(), delta * t, s.as_ref(), out)
             }
         }
         else if let Some(s) = repr.downcast_ref::<Ls>() {

--- a/examples2d/nphysics_testbed2d/src/engine.rs
+++ b/examples2d/nphysics_testbed2d/src/engine.rs
@@ -6,45 +6,20 @@ use rand::{SeedableRng, XorShiftRng, Rng};
 use sfml::graphics::RenderWindow;
 use na::{Pnt2, Pnt3, Iso2};
 use na;
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::{WorldObject, RigidBodyHandle, SensorHandle};
 use ncollide::inspection::Repr2;
 use ncollide::shape;
 use camera::Camera;
-use objects::ball::Ball;
-use objects::box_node::Box;
-use objects::lines::Lines;
-use objects::segment::Segment;
+use objects::{SceneNode, Ball, Box, Lines, Segment};
 
-pub enum SceneNode<'a> {
-    BallNode(Ball<'a>),
-    BoxNode(Box<'a>),
-    LinesNode(Lines),
-    SegmentNode(Segment)
-}
-
-impl<'a> SceneNode<'a> {
-    pub fn select(&mut self) {
-        match *self {
-            SceneNode::BallNode(ref mut n) => n.select(),
-            SceneNode::BoxNode(ref mut n) => n.select(),
-            SceneNode::LinesNode(ref mut n) => n.select(),
-            SceneNode::SegmentNode(ref mut n) => n.select(),
-        }
-    }
-
-    pub fn unselect(&mut self) {
-        match *self {
-            SceneNode::BallNode(ref mut n) => n.unselect(),
-            SceneNode::BoxNode(ref mut n) => n.unselect(),
-            SceneNode::LinesNode(ref mut n) => n.unselect(),
-            SceneNode::SegmentNode(ref mut n) => n.unselect(),
-        }
-    }
-}
+pub type GraphicsManagerHandle = Rc<RefCell<GraphicsManager<'static>>>;
 
 pub struct GraphicsManager<'a> {
+    // NOTE: sensors and rigid bodies are not on the same hashmap because we want do draw sensors
+    // after all the rigid bodies.
     rand:      XorShiftRng,
     rb2sn:     HashMap<usize, Vec<SceneNode<'a>>>,
+    s2sn:      HashMap<usize, Vec<SceneNode<'a>>>,
     obj2color: HashMap<usize, Pnt3<u8>>
 }
 
@@ -53,29 +28,32 @@ impl<'a> GraphicsManager<'a> {
         GraphicsManager {
             rand:      SeedableRng::from_seed([0, 1, 2, 3]),
             rb2sn:     HashMap::new(),
+            s2sn:      HashMap::new(),
             obj2color: HashMap::new()
         }
     }
 
-    pub fn add(&mut self, body: Rc<RefCell<RigidBody<f32>>>) {
-
+    pub fn add(&mut self, object: WorldObject<f32>) {
         let nodes = {
-            let rb    = body.borrow();
+            let bobject = object.borrow();
             let mut nodes = Vec::new();
 
-            self.add_shape(body.clone(), na::one(), rb.shape_ref(), &mut nodes);
+            self.add_shape(object.clone(), na::one(), bobject.shape_ref(), &mut nodes);
 
             nodes
         };
 
-        self.rb2sn.insert(&*body as *const RefCell<RigidBody<f32>> as usize, nodes);
+        match object {
+            WorldObject::RigidBody(ref rb) => { self.rb2sn.insert(WorldObject::rigid_body_uid(rb), nodes); },
+            WorldObject::Sensor(ref s)     => { self.s2sn.insert(WorldObject::sensor_uid(s), nodes); }
+        }
     }
 
     fn add_shape(&mut self,
-                 body:  Rc<RefCell<RigidBody<f32>>>,
-                 delta: Iso2<f32>,
-                 shape: &Repr2<f32>,
-                 out:   &mut Vec<SceneNode<'a>>) {
+                 object: WorldObject<f32>,
+                 delta:  Iso2<f32>,
+                 shape:  &Repr2<f32>,
+                 out:    &mut Vec<SceneNode<'a>>) {
         type Pl = shape::Plane2<f32>;
         type Bl = shape::Ball2<f32>;
         type Cx = shape::Convex2<f32>;
@@ -89,27 +67,27 @@ impl<'a> GraphicsManager<'a> {
         let repr = shape.repr();
 
         if let Some(s) = repr.downcast_ref::<Pl>() {
-            self.add_plane(body, s, out)
+            self.add_plane(object, s, out)
         }
         else if let Some(s) = repr.downcast_ref::<Bl>() {
-            self.add_ball(body, delta, s, out)
+            self.add_ball(object, delta, s, out)
         }
         else if let Some(s) = repr.downcast_ref::<Bo>() {
-            self.add_box(body, delta, s, out)
+            self.add_box(object, delta, s, out)
         }
         else if let Some(s) = repr.downcast_ref::<Cx>() {
-            self.add_convex(body, delta, s, out)
+            self.add_convex(object, delta, s, out)
         }
         else if let Some(s) = repr.downcast_ref::<Se>() {
-            self.add_segment(body, delta, s, out)
+            self.add_segment(object, delta, s, out)
         }
         else if let Some(s) = repr.downcast_ref::<Cm>() {
             for &(t, ref s) in s.shapes().iter() {
-                self.add_shape(body.clone(), delta * t, &***s, out)
+                self.add_shape(object.clone(), delta * t, &***s, out)
             }
         }
         else if let Some(s) = repr.downcast_ref::<Ls>() {
-            self.add_lines(body, delta, s, out)
+            self.add_lines(object, delta, s, out)
         }
         else {
             panic!("Not yet implemented.")
@@ -118,28 +96,28 @@ impl<'a> GraphicsManager<'a> {
     }
 
     fn add_plane(&mut self,
-                 _: Rc<RefCell<RigidBody<f32>>>,
+                 _: WorldObject<f32>,
                  _: &shape::Plane2<f32>,
                  _: &mut Vec<SceneNode>) {
     }
 
     fn add_ball(&mut self,
-                body:  Rc<RefCell<RigidBody<f32>>>,
-                delta: Iso2<f32>,
-                shape: &shape::Ball2<f32>,
-                out:   &mut Vec<SceneNode>) {
-        let color = self.color_for_object(&body);
-        let margin = body.borrow().margin();
-        out.push(SceneNode::BallNode(Ball::new(body, delta, shape.radius() + margin, color)))
+                object: WorldObject<f32>,
+                delta:  Iso2<f32>,
+                shape:  &shape::Ball2<f32>,
+                out:    &mut Vec<SceneNode>) {
+        let color = self.color_for_object(&object);
+        let margin = object.borrow().margin();
+        out.push(SceneNode::BallNode(Ball::new(object, delta, shape.radius() + margin, color)))
     }
     
     fn add_convex(&mut self,
-                body:  Rc<RefCell<RigidBody<f32>>>,
-                delta: Iso2<f32>,
-                shape: &shape::Convex2<f32>,
-                out:   &mut Vec<SceneNode>) {
-        let color = self.color_for_object(&body);
-        //let margin = body.borrow().margin();
+                  object: WorldObject<f32>,
+                  delta:  Iso2<f32>,
+                  shape:  &shape::Convex2<f32>,
+                  out:    &mut Vec<SceneNode>) {
+        let color = self.color_for_object(&object);
+        //let margin = object.borrow().margin();
         let points = shape.points();
         let vector = points.iter().cloned().collect();
         let vs = Arc::new(vector);
@@ -148,76 +126,77 @@ impl<'a> GraphicsManager<'a> {
 	    Arc::new( (0..limit as usize).map(|x| Pnt2::new(x, (x+(1 as usize)) % limit )).collect() )
         };
         
-        out.push(SceneNode::LinesNode(Lines::new(body, delta, vs, is, color)))
+        out.push(SceneNode::LinesNode(Lines::new(object, delta, vs, is, color)))
     }
 
     fn add_lines(&mut self,
-                 body:  Rc<RefCell<RigidBody<f32>>>,
-                 delta: Iso2<f32>,
-                 shape: &shape::Polyline2<f32>,
-                 out:   &mut Vec<SceneNode>) {
+                 object: WorldObject<f32>,
+                 delta:  Iso2<f32>,
+                 shape:  &shape::Polyline2<f32>,
+                 out:    &mut Vec<SceneNode>) {
 
-        let color = self.color_for_object(&body);
+        let color = self.color_for_object(&object);
 
         let vs = shape.vertices().clone();
         let is = shape.indices().clone();
 
-        out.push(SceneNode::LinesNode(Lines::new(body, delta, vs, is, color)))
+        out.push(SceneNode::LinesNode(Lines::new(object, delta, vs, is, color)))
     }
 
 
     fn add_box(&mut self,
-               body:  Rc<RefCell<RigidBody<f32>>>,
-               delta: Iso2<f32>,
-               shape: &shape::Cuboid2<f32>,
-               out:   &mut Vec<SceneNode>) {
+               object: WorldObject<f32>,
+               delta:  Iso2<f32>,
+               shape:  &shape::Cuboid2<f32>,
+               out:    &mut Vec<SceneNode>) {
         let rx = shape.half_extents().x;
         let ry = shape.half_extents().y;
-        let margin = body.borrow().margin();
+        let margin = object.borrow().margin();
 
-        let color = self.color_for_object(&body);
+        let color = self.color_for_object(&object);
 
-        out.push(SceneNode::BoxNode(Box::new(body, delta, rx + margin, ry + margin, color)))
+        out.push(SceneNode::BoxNode(Box::new(object, delta, rx + margin, ry + margin, color)))
     }
 
     fn add_segment(&mut self,
-                   body:  Rc<RefCell<RigidBody<f32>>>,
-                   delta: Iso2<f32>,
-                   shape: &shape::Segment2<f32>,
-                   out:   &mut Vec<SceneNode>) {
+                   object: WorldObject<f32>,
+                   delta:  Iso2<f32>,
+                   shape:  &shape::Segment2<f32>,
+                   out:    &mut Vec<SceneNode>) {
         let a = shape.a();
         let b = shape.b();
 
-        let color = self.color_for_object(&body);
+        let color = self.color_for_object(&object);
 
-        out.push(SceneNode::SegmentNode(Segment::new(body, delta, *a, *b, color)))
+        out.push(SceneNode::SegmentNode(Segment::new(object, delta, *a, *b, color)))
     }
 
 
     pub fn clear(&mut self) {
         self.rb2sn.clear();
+        self.s2sn.clear();
     }
 
     pub fn draw(&mut self, rw: &mut RenderWindow, c: &Camera) {
         c.activate_scene(rw);
 
-        for (_, ns) in self.rb2sn.iter_mut() {
+        for (_, ns) in self.rb2sn.iter_mut().chain(self.s2sn.iter_mut()) {
             for n in ns.iter_mut() {
                 match *n {
-                    SceneNode::BoxNode(ref mut n) => n.update(),
-                    SceneNode::BallNode(ref mut n) => n.update(),
-                    SceneNode::LinesNode(ref mut n) => n.update(),
+                    SceneNode::BoxNode(ref mut n)     => n.update(),
+                    SceneNode::BallNode(ref mut n)    => n.update(),
+                    SceneNode::LinesNode(ref mut n)   => n.update(),
                     SceneNode::SegmentNode(ref mut n) => n.update(),
                 }
             }
         }
 
-        for (_, ns) in self.rb2sn.iter_mut() {
+        for (_, ns) in self.rb2sn.iter_mut().chain(self.s2sn.iter_mut()) {
             for n in ns.iter_mut() {
                 match *n {
-                    SceneNode::BoxNode(ref n) => n.draw(rw),
-                    SceneNode::BallNode(ref n) => n.draw(rw),
-                    SceneNode::LinesNode(ref n) => n.draw(rw),
+                    SceneNode::BoxNode(ref n)     => n.draw(rw),
+                    SceneNode::BallNode(ref n)    => n.draw(rw),
+                    SceneNode::LinesNode(ref n)   => n.draw(rw),
                     SceneNode::SegmentNode(ref n) => n.draw(rw),
                 }
             }
@@ -226,22 +205,55 @@ impl<'a> GraphicsManager<'a> {
         c.activate_ui(rw);
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<u8>) {
-        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
-        self.obj2color.insert(key, color);
-    }
+    fn set_color(&mut self, key: usize, color: Pnt3<f32>) {
+        let color = Pnt3::new(
+            (color.x * 255.0) as u8,
+            (color.y * 255.0) as u8,
+            (color.z * 255.0) as u8
+        );
 
-    pub fn color_for_object(&mut self, body: &Rc<RefCell<RigidBody<f32>>>) -> Pnt3<u8> {
-        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
-        match self.obj2color.get(&key) {
-            Some(color) => return *color,
-            None => { }
+        self.obj2color.insert(key, color);
+
+        if let Some(sns) = self.rb2sn.get_mut(&key) {
+            for sn in sns.iter_mut() {
+                sn.set_color(color)
+            }
         }
 
-        let color = Pnt3::new(
+        if let Some(sns) = self.s2sn.get_mut(&key) {
+            for sn in sns.iter_mut() {
+                sn.set_color(color)
+            }
+        }
+    }
+
+    pub fn set_rigid_body_color(&mut self, object: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+        self.set_color(WorldObject::rigid_body_uid(object), color)
+    }
+
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+        self.set_color(WorldObject::sensor_uid(sensor), color)
+    }
+
+    pub fn color_for_object(&mut self, object: &WorldObject<f32>) -> Pnt3<u8> {
+        let key = object.uid();
+        match self.obj2color.get(&key) {
+            Some(color) => return *color,
+            None        => { }
+        }
+
+        let mut color = Pnt3::new(
             self.rand.gen_range(0usize, 256) as u8,
             self.rand.gen_range(0usize, 256) as u8,
             self.rand.gen_range(0usize, 256) as u8);
+
+        if let WorldObject::Sensor(ref s) = *object {
+            if let Some(parent) = s.borrow().parent() {
+                if let Some(pcolor) = self.obj2color.get(&WorldObject::rigid_body_uid(parent)) {
+                    color = *pcolor;
+                }
+            }
+        }
 
 
         self.obj2color.insert(key, color);
@@ -249,7 +261,11 @@ impl<'a> GraphicsManager<'a> {
         color
     }
 
-    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>) -> Option<&mut Vec<SceneNode<'a>>> {
-        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody<f32>> as usize))
+    pub fn rigid_body_to_scene_node(&mut self, rb: &RigidBodyHandle<f32>) -> Option<&mut Vec<SceneNode<'a>>> {
+        self.rb2sn.get_mut(&WorldObject::rigid_body_uid(rb))
+    }
+
+    pub fn sensor_to_scene_node(&mut self, sensor: &SensorHandle<f32>) -> Option<&mut Vec<SceneNode<'a>>> {
+        self.s2sn.get_mut(&WorldObject::sensor_uid(sensor))
     }
 }

--- a/examples2d/nphysics_testbed2d/src/fps.rs
+++ b/examples2d/nphysics_testbed2d/src/fps.rs
@@ -1,6 +1,5 @@
-use sfml::system::vector2;
-use sfml::traits::Drawable;
-use sfml::graphics::{Font, Text, Color, RenderTarget};
+use sfml::system::{Vector2f, Vector2i};
+use sfml::graphics::{Font, Text, Color, RenderTarget, Drawable, Transformable};
 use sfml::graphics;
 use time;
 
@@ -14,7 +13,7 @@ impl<'a> Fps<'a> {
     pub fn new(font: &'a Font) -> Fps<'a> {
         let mut txt = Text::new().unwrap();
         txt.set_font(font);
-        txt.set_position(&vector2::Vector2f { x: 0.0, y: 0.0 });
+        txt.set_position(&Vector2f::new(0.0, 0.0));
         txt.set_color(&Color::new_rgb(255, 255, 255));
 
         Fps {
@@ -41,8 +40,8 @@ impl<'a> Fps<'a> {
 
         let v = rw.get_view();
 
-        self.fps.set_position(&rw.map_pixel_to_coords(&vector2::Vector2i { x: 0, y : 0 }, &v));
-        self.fps.set_string(&elapsed.to_string()[..]);
+        self.fps.set_position(&rw.map_pixel_to_coords(&Vector2i { x: 0, y : 0 }, &v));
+        self.fps.set_string(&format!("Time: {:.*}sec.", 4, elapsed)[..]);
         rw.draw(&self.fps);
     }
 }

--- a/examples2d/nphysics_testbed2d/src/lib.rs
+++ b/examples2d/nphysics_testbed2d/src/lib.rs
@@ -10,6 +10,7 @@ extern crate nphysics2d;
 
 
 pub use testbed::Testbed;
+pub use engine::{GraphicsManager, GraphicsManagerHandle};
 pub use testbed::{CallBackMode, CallBackId};
 
 mod testbed;
@@ -19,9 +20,4 @@ mod camera;
 mod fps;
 mod draw_helper;
 
-mod objects {
-    pub mod ball;
-    pub mod box_node;
-    pub mod lines;
-    pub mod segment;
-}
+pub mod objects;

--- a/examples2d/nphysics_testbed2d/src/objects/ball.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/ball.rs
@@ -1,24 +1,24 @@
 use sfml::graphics;
 use sfml::graphics::{CircleShape, Color, RenderTarget, Shape, Transformable};
 use sfml::system::Vector2f;
-use na::{Pnt3, Iso2};
+use na::{Point3, Isometry2};
 use nphysics2d::object::WorldObject;
 use draw_helper::DRAW_SCALE;
 use objects;
 
 pub struct Ball<'a> {
-    color:  Pnt3<u8>,
-    base_color: Pnt3<u8>,
-    delta:  Iso2<f32>,
+    color:  Point3<u8>,
+    base_color: Point3<u8>,
+    delta:  Isometry2<f32>,
     object: WorldObject<f32>,
     gfx:    CircleShape<'a>
 }
 
 impl<'a> Ball<'a> {
     pub fn new(object: WorldObject<f32>,
-               delta:  Iso2<f32>,
+               delta:  Isometry2<f32>,
                radius: f32,
-               color:  Pnt3<u8>)
+               color:  Point3<u8>)
                -> Ball<'a> {
         let dradius = radius as f32 * DRAW_SCALE;
 
@@ -47,13 +47,13 @@ impl<'a> Ball<'a> {
         rw.draw(&self.gfx);
     }
 
-    pub fn set_color(&mut self, color: Pnt3<u8>) {
+    pub fn set_color(&mut self, color: Point3<u8>) {
         self.color      = color;
         self.base_color = color;
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(200, 0, 0);
+        self.color = Point3::new(200, 0, 0);
     }
 
     pub fn unselect(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/ball.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/ball.rs
@@ -1,40 +1,38 @@
-use std::f32;
-use std::rc::Rc;
-use std::cell::RefCell;
 use sfml::graphics;
-use sfml::graphics::{CircleShape, Color, RenderTarget};
-use sfml::system::vector2;
+use sfml::graphics::{CircleShape, Color, RenderTarget, Shape, Transformable};
+use sfml::system::Vector2f;
 use na::{Pnt3, Iso2};
-use na;
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::WorldObject;
 use draw_helper::DRAW_SCALE;
+use objects;
 
 pub struct Ball<'a> {
-    color: Pnt3<u8>,
+    color:  Pnt3<u8>,
     base_color: Pnt3<u8>,
-    delta: Iso2<f32>,
-    body:  Rc<RefCell<RigidBody<f32>>>,
-    gfx:   CircleShape<'a>
+    delta:  Iso2<f32>,
+    object: WorldObject<f32>,
+    gfx:    CircleShape<'a>
 }
 
 impl<'a> Ball<'a> {
-    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(object: WorldObject<f32>,
                delta:  Iso2<f32>,
                radius: f32,
-               color:  Pnt3<u8>) -> Ball<'a> {
+               color:  Pnt3<u8>)
+               -> Ball<'a> {
         let dradius = radius as f32 * DRAW_SCALE;
 
         let mut res = Ball {
-            color: color,
+            color:      color,
             base_color: color,
-            delta: delta,
-            gfx:   CircleShape::new().unwrap(),
-            body:  body
+            delta:      delta,
+            gfx:        CircleShape::new().unwrap(),
+            object:     object
         };
 
         res.gfx.set_fill_color(&Color::new_rgb(color.x, color.y, color.z));
         res.gfx.set_radius(dradius);
-        res.gfx.set_origin(&vector2::Vector2f { x: dradius, y: dradius }); 
+        res.gfx.set_origin(&Vector2f::new(dradius, dradius)); 
 
         res
     }
@@ -42,29 +40,16 @@ impl<'a> Ball<'a> {
 
 impl<'a> Ball<'a> {
     pub fn update(&mut self) {
-        let body = self.body.borrow();
-        let transform = *body.position() * self.delta;
-        let pos = na::translation(&transform);
-        let rot = na::rotation(&transform);
-
-        self.gfx.set_position(&vector2::Vector2f {
-            x: pos.x as f32 * DRAW_SCALE,
-            y: pos.y as f32 * DRAW_SCALE
-        });
-        self.gfx.set_rotation(rot.x * 180.0 / f32::consts::PI as f32);
-
-        if body.is_active() {
-            self.gfx.set_fill_color(
-                &Color::new_rgb(self.color.x, self.color.y, self.color.z));
-        }
-        else {
-            self.gfx.set_fill_color(
-                &Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4));
-        }
+        objects::update_scene_node(&mut self.gfx, &self.object, &self.color, &self.delta)
     }
 
     pub fn draw(&self, rw: &mut graphics::RenderWindow) {
         rw.draw(&self.gfx);
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<u8>) {
+        self.color      = color;
+        self.base_color = color;
     }
 
     pub fn select(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/box_node.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/box_node.rs
@@ -1,42 +1,39 @@
-use std::f32;
-use std::rc::Rc;
-use std::cell::RefCell;
 use sfml::graphics;
-use sfml::graphics::{RectangleShape, Color, RenderTarget};
-use sfml::system::vector2;
+use sfml::graphics::{RectangleShape, Color, RenderTarget, Shape, Transformable};
+use sfml::system::Vector2f;
 use na::{Pnt3, Iso2};
-use na;
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::WorldObject;
+use objects;
 use draw_helper::DRAW_SCALE;
 
 pub struct Box<'a> {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body: Rc<RefCell<RigidBody<f32>>>,
+    object: WorldObject<f32>,
     gfx: RectangleShape<'a>
 }
 
 impl<'a> Box<'a> {
-    pub fn new(body:  Rc<RefCell<RigidBody<f32>>>,
-               delta: Iso2<f32>,
-               rx:    f32,
-               ry:    f32,
-               color: Pnt3<u8>) -> Box<'a> {
+    pub fn new(object: WorldObject<f32>,
+               delta:  Iso2<f32>,
+               rx:     f32,
+               ry:     f32,
+               color:  Pnt3<u8>) -> Box<'a> {
         let mut res = Box {
             color: color,
             base_color: color,
             delta: delta,
             gfx: RectangleShape::new().unwrap(),
-            body: body
+            object: object
         };
 
         let drx = rx as f32 * DRAW_SCALE;
         let dry = ry as f32 * DRAW_SCALE;
 
         res.gfx.set_fill_color(&Color::new_rgb(color.x, color.y, color.z));
-        res.gfx.set_size(&vector2::Vector2f { x: drx * 2.0, y: dry * 2.0 });
-        res.gfx.set_origin(&vector2::Vector2f { x: drx, y: dry });
+        res.gfx.set_size(&Vector2f { x: drx * 2.0, y: dry * 2.0 });
+        res.gfx.set_origin(&Vector2f { x: drx, y: dry });
 
         res
     }
@@ -44,29 +41,16 @@ impl<'a> Box<'a> {
 
 impl<'a> Box<'a> {
     pub fn update(&mut self) {
-        let body     = self.body.borrow();
-        let transform = *body.position() * self.delta;
-        let pos = na::translation(&transform);
-        let rot = na::rotation(&transform);
-
-        self.gfx.set_position(&vector2::Vector2f {
-            x: pos.x as f32 * DRAW_SCALE,
-            y: pos.y as f32 * DRAW_SCALE
-        });
-        self.gfx.set_rotation(rot.x * 180.0 / f32::consts::PI as f32);
-
-        if body.is_active() {
-            self.gfx.set_fill_color(
-                &Color::new_rgb(self.color.x, self.color.y, self.color.z));
-        }
-        else {
-            self.gfx.set_fill_color(
-                &Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4));
-        }
+        objects::update_scene_node(&mut self.gfx, &self.object, &self.color, &self.delta)
     }
 
     pub fn draw(&self, rw: &mut graphics::RenderWindow) {
         rw.draw(&self.gfx);
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<u8>) {
+        self.color      = color;
+        self.base_color = color;
     }
 
     pub fn select(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/box_node.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/box_node.rs
@@ -1,25 +1,25 @@
 use sfml::graphics;
 use sfml::graphics::{RectangleShape, Color, RenderTarget, Shape, Transformable};
 use sfml::system::Vector2f;
-use na::{Pnt3, Iso2};
+use na::{Point3, Isometry2};
 use nphysics2d::object::WorldObject;
 use objects;
 use draw_helper::DRAW_SCALE;
 
 pub struct Box<'a> {
-    color: Pnt3<u8>,
-    base_color: Pnt3<u8>,
-    delta: Iso2<f32>,
+    color: Point3<u8>,
+    base_color: Point3<u8>,
+    delta: Isometry2<f32>,
     object: WorldObject<f32>,
     gfx: RectangleShape<'a>
 }
 
 impl<'a> Box<'a> {
     pub fn new(object: WorldObject<f32>,
-               delta:  Iso2<f32>,
+               delta:  Isometry2<f32>,
                rx:     f32,
                ry:     f32,
-               color:  Pnt3<u8>) -> Box<'a> {
+               color:  Point3<u8>) -> Box<'a> {
         let mut res = Box {
             color: color,
             base_color: color,
@@ -48,13 +48,13 @@ impl<'a> Box<'a> {
         rw.draw(&self.gfx);
     }
 
-    pub fn set_color(&mut self, color: Pnt3<u8>) {
+    pub fn set_color(&mut self, color: Point3<u8>) {
         self.color      = color;
         self.base_color = color;
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(200, 0, 0);
+        self.color = Point3::new(200, 0, 0);
     }
 
     pub fn unselect(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/lines.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/lines.rs
@@ -1,25 +1,25 @@
 use std::sync::Arc;
 use sfml::graphics;
 use sfml::graphics::Color;
-use na::{Pnt2, Pnt3, Iso2};
+use na::{Point2, Point3, Isometry2};
 use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
 use draw_helper::draw_line;
 
 pub struct Lines {
-    color: Pnt3<u8>,
-    base_color: Pnt3<u8>,
-    delta: Iso2<f32>,
+    color: Point3<u8>,
+    base_color: Point3<u8>,
+    delta: Isometry2<f32>,
     object: WorldObject<f32>,
-    indices: Arc<Vec<Pnt2<usize>>>,
-    vertices: Arc<Vec<Pnt2<f32>>>
+    indices: Arc<Vec<Point2<usize>>>,
+    vertices: Arc<Vec<Point2<f32>>>
 }
 
 impl Lines {
     pub fn new(object:   WorldObject<f32>,
-               delta:    Iso2<f32>,
-               vertices: Arc<Vec<Pnt2<f32>>>,
-               indices:  Arc<Vec<Pnt2<usize>>>,
-               color:    Pnt3<u8>)
+               delta:    Isometry2<f32>,
+               vertices: Arc<Vec<Point2<f32>>>,
+               indices:  Arc<Vec<Point2<usize>>>,
+               color:    Point3<u8>)
                -> Lines {
         Lines {
             color: color,
@@ -56,13 +56,13 @@ impl Lines {
         }
     }
 
-    pub fn set_color(&mut self, color: Pnt3<u8>) {
+    pub fn set_color(&mut self, color: Point3<u8>) {
         self.color      = color;
         self.base_color = color;
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(200, 0, 0);
+        self.color = Point3::new(200, 0, 0);
     }
 
     pub fn unselect(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/lines.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/lines.rs
@@ -1,32 +1,31 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::sync::Arc;
 use sfml::graphics;
 use sfml::graphics::Color;
 use na::{Pnt2, Pnt3, Iso2};
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
 use draw_helper::draw_line;
 
 pub struct Lines {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body: Rc<RefCell<RigidBody<f32>>>,
+    object: WorldObject<f32>,
     indices: Arc<Vec<Pnt2<usize>>>,
     vertices: Arc<Vec<Pnt2<f32>>>
 }
 
 impl Lines {
-    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(object:   WorldObject<f32>,
                delta:    Iso2<f32>,
                vertices: Arc<Vec<Pnt2<f32>>>,
                indices:  Arc<Vec<Pnt2<usize>>>,
-               color:    Pnt3<u8>) -> Lines {
+               color:    Pnt3<u8>)
+               -> Lines {
         Lines {
             color: color,
             base_color: color,
             delta: delta,
-            body: body,
+            object: object,
             vertices: vertices,
             indices: indices
         }
@@ -38,12 +37,15 @@ impl Lines {
     }
 
     pub fn draw(&self, rw: &mut graphics::RenderWindow) {
-        let body      = self.body.borrow();
-        let transform = *body.position() * self.delta;
-        let color = match body.is_active() {
-            true  => Color::new_rgb(self.color.x, self.color.y, self.color.z),
-            false => Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4)
-        };
+        let object    = self.object.borrow();
+        let transform = object.position() * self.delta;
+        let mut color = Color::new_rgb(self.color.x, self.color.y, self.color.z);
+        
+        if let WorldObjectBorrowed::RigidBody(rb) = object {
+            if !rb.is_active() {
+                color = Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4);
+            }
+        }
 
         let vs = &*self.vertices;
 
@@ -52,6 +54,11 @@ impl Lines {
             let gsv1 = transform * vs[is.y];
             draw_line(rw, &gsv0, &gsv1, &color);
         }
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<u8>) {
+        self.color      = color;
+        self.base_color = color;
     }
 
     pub fn select(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/mod.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/mod.rs
@@ -1,0 +1,11 @@
+pub use self::ball::Ball;
+pub use self::box_node::Box;
+pub use self::lines::Lines;
+pub use self::segment::Segment;
+pub use self::scene_node::{SceneNode, update_scene_node};
+
+mod ball;
+mod box_node;
+mod lines;
+mod segment;
+mod scene_node;

--- a/examples2d/nphysics_testbed2d/src/objects/scene_node.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/scene_node.rs
@@ -1,7 +1,7 @@
 use std::f32;
 use sfml::graphics::{Color, Shape, Transformable};
 use sfml::system::Vector2f;
-use na::{self, Pnt3, Iso2};
+use na::{self, Point3, Isometry2};
 use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
 use objects::{Ball, Box, Lines, Segment};
 use draw_helper::DRAW_SCALE;
@@ -32,7 +32,7 @@ impl<'a> SceneNode<'a> {
         }
     }
 
-    pub fn set_color(&mut self, color: Pnt3<u8>) {
+    pub fn set_color(&mut self, color: Point3<u8>) {
         match *self {
             SceneNode::BallNode(ref mut n)    => n.set_color(color),
             SceneNode::BoxNode(ref mut n)     => n.set_color(color),
@@ -44,8 +44,8 @@ impl<'a> SceneNode<'a> {
 
 pub fn update_scene_node<'a, T>(node:   &mut T,
                                 object: &WorldObject<f32>,
-                                color:  &Pnt3<u8>,
-                                delta:  &Iso2<f32>)
+                                color:  &Point3<u8>,
+                                delta:  &Isometry2<f32>)
         where T: Transformable + Shape<'a> {
     let bobject   = object.borrow();
     let transform = bobject.position() * *delta;

--- a/examples2d/nphysics_testbed2d/src/objects/scene_node.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/scene_node.rs
@@ -1,0 +1,74 @@
+use std::f32;
+use sfml::graphics::{Color, Shape, Transformable};
+use sfml::system::Vector2f;
+use na::{self, Pnt3, Iso2};
+use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
+use objects::{Ball, Box, Lines, Segment};
+use draw_helper::DRAW_SCALE;
+
+pub enum SceneNode<'a> {
+    BallNode(Ball<'a>),
+    BoxNode(Box<'a>),
+    LinesNode(Lines),
+    SegmentNode(Segment)
+}
+
+impl<'a> SceneNode<'a> {
+    pub fn select(&mut self) {
+        match *self {
+            SceneNode::BallNode(ref mut n)    => n.select(),
+            SceneNode::BoxNode(ref mut n)     => n.select(),
+            SceneNode::LinesNode(ref mut n)   => n.select(),
+            SceneNode::SegmentNode(ref mut n) => n.select(),
+        }
+    }
+
+    pub fn unselect(&mut self) {
+        match *self {
+            SceneNode::BallNode(ref mut n)    => n.unselect(),
+            SceneNode::BoxNode(ref mut n)     => n.unselect(),
+            SceneNode::LinesNode(ref mut n)   => n.unselect(),
+            SceneNode::SegmentNode(ref mut n) => n.unselect(),
+        }
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<u8>) {
+        match *self {
+            SceneNode::BallNode(ref mut n)    => n.set_color(color),
+            SceneNode::BoxNode(ref mut n)     => n.set_color(color),
+            SceneNode::LinesNode(ref mut n)   => n.set_color(color),
+            SceneNode::SegmentNode(ref mut n) => n.set_color(color),
+        }
+    }
+}
+
+pub fn update_scene_node<'a, T>(node:   &mut T,
+                                object: &WorldObject<f32>,
+                                color:  &Pnt3<u8>,
+                                delta:  &Iso2<f32>)
+        where T: Transformable + Shape<'a> {
+    let bobject   = object.borrow();
+    let transform = bobject.position() * *delta;
+    let pos       = na::translation(&transform);
+    let rot       = na::rotation(&transform);
+
+    node.set_position(&Vector2f::new(pos.x as f32 * DRAW_SCALE, pos.y as f32 * DRAW_SCALE));
+    node.set_rotation(rot.x * 180.0 / f32::consts::PI as f32);
+
+    match bobject {
+        WorldObjectBorrowed::Sensor(_) => {
+            // FIXME: what is the impact on performance of doing those at each update.
+            node.set_fill_color(&Color::new_rgba(0, 0, 0, 0));
+            node.set_outline_thickness(2.0);
+            node.set_outline_color(&Color::new_rgb(color.x, color.y, color.z));
+        },
+        WorldObjectBorrowed::RigidBody(rb) => {
+            if !rb.is_active() {
+                node.set_fill_color(&Color::new_rgb(color.x / 4, color.y / 4, color.z / 4));
+            }
+            else {
+                node.set_fill_color(&Color::new_rgb(color.x, color.y, color.z));
+            }
+        }
+    }
+}

--- a/examples2d/nphysics_testbed2d/src/objects/segment.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/segment.rs
@@ -1,24 +1,24 @@
 use sfml::graphics;
 use sfml::graphics::Color;
-use na::{Pnt2, Pnt3, Iso2};
+use na::{Point2, Point3, Isometry2};
 use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
 use draw_helper::draw_line;
 
 pub struct Segment {
-    color: Pnt3<u8>,
-    base_color: Pnt3<u8>,
-    delta: Iso2<f32>,
+    color: Point3<u8>,
+    base_color: Point3<u8>,
+    delta: Isometry2<f32>,
     object:  WorldObject<f32>,
-    a:     Pnt2<f32>,
-    b:     Pnt2<f32>,
+    a:     Point2<f32>,
+    b:     Point2<f32>,
 }
 
 impl Segment {
     pub fn new(object: WorldObject<f32>,
-               delta:  Iso2<f32>,
-               a:      Pnt2<f32>,
-               b:      Pnt2<f32>,
-               color:  Pnt3<u8>)
+               delta:  Isometry2<f32>,
+               a:      Point2<f32>,
+               b:      Point2<f32>,
+               color:  Point3<u8>)
                -> Segment {
         Segment {
             color: color,
@@ -51,13 +51,13 @@ impl Segment {
         draw_line(rw, &ga, &gb, &color);
     }
 
-    pub fn set_color(&mut self, color: Pnt3<u8>) {
+    pub fn set_color(&mut self, color: Point3<u8>) {
         self.color      = color;
         self.base_color = color;
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(200, 0, 0);
+        self.color = Point3::new(200, 0, 0);
     }
 
     pub fn unselect(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/objects/segment.rs
+++ b/examples2d/nphysics_testbed2d/src/objects/segment.rs
@@ -1,31 +1,30 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use sfml::graphics;
 use sfml::graphics::Color;
 use na::{Pnt2, Pnt3, Iso2};
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::{WorldObject, WorldObjectBorrowed};
 use draw_helper::draw_line;
 
 pub struct Segment {
     color: Pnt3<u8>,
     base_color: Pnt3<u8>,
     delta: Iso2<f32>,
-    body:  Rc<RefCell<RigidBody<f32>>>,
+    object:  WorldObject<f32>,
     a:     Pnt2<f32>,
     b:     Pnt2<f32>,
 }
 
 impl Segment {
-    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
-               delta:    Iso2<f32>,
-               a:        Pnt2<f32>,
-               b:        Pnt2<f32>,
-               color:    Pnt3<u8>) -> Segment {
+    pub fn new(object: WorldObject<f32>,
+               delta:  Iso2<f32>,
+               a:      Pnt2<f32>,
+               b:      Pnt2<f32>,
+               color:  Pnt3<u8>)
+               -> Segment {
         Segment {
             color: color,
             base_color: color,
             delta: delta,
-            body: body,
+            object: object,
             a:    a,
             b:    b
         }
@@ -37,16 +36,24 @@ impl Segment {
     }
 
     pub fn draw(&self, rw: &mut graphics::RenderWindow) {
-        let body      = self.body.borrow();
-        let transform = *body.position() * self.delta;
-        let color = match body.is_active() {
-            true  => Color::new_rgb(self.color.x, self.color.y, self.color.z),
-            false => Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4)
-        };
+        let object    = self.object.borrow();
+        let transform = object.position() * self.delta;
+        let mut color = Color::new_rgb(self.color.x, self.color.y, self.color.z);
+        
+        if let WorldObjectBorrowed::RigidBody(rb) = object {
+            if !rb.is_active() {
+                color = Color::new_rgb(self.color.x / 4, self.color.y / 4, self.color.z / 4);
+            }
+        }
 
         let ga = transform * self.a;
         let gb = transform * self.b;
         draw_line(rw, &ga, &gb, &color);
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<u8>) {
+        self.color      = color;
+        self.base_color = color;
     }
 
     pub fn select(&mut self) {

--- a/examples2d/nphysics_testbed2d/src/testbed.rs
+++ b/examples2d/nphysics_testbed2d/src/testbed.rs
@@ -2,21 +2,21 @@ use std::env;
 use std::rc::Rc;
 use std::cell::RefCell;
 use sfml::graphics::{RenderWindow, RenderTarget, Font};
-use sfml::window::{ContextSettings, VideoMode, Close};
-use sfml::window::event;
-use sfml::window::keyboard::Key;
-use sfml::window::mouse::MouseButton;
+use sfml::window::{ContextSettings, VideoMode};
+use sfml::window::window_style;
+use sfml::window::event::Event;
+use sfml::window::{Key, MouseButton};
 use sfml::graphics::Color;
-use sfml::system::vector2::Vector2i;
+use sfml::system::Vector2i;
 use na::{Pnt2, Pnt3, Iso2};
 use na;
 use ncollide::world::CollisionGroups;
 use nphysics2d::world::World;
-use nphysics2d::object::RigidBody;
+use nphysics2d::object::{WorldObject, RigidBodyHandle, SensorHandle};
 use nphysics2d::detection::joint::{Fixed, Anchor};
 use camera::Camera;
 use fps::Fps;
-use engine::GraphicsManager;
+use engine::{GraphicsManager, GraphicsManagerHandle};
 use draw_helper;
 
 fn usage(exe_name: &str) {
@@ -52,11 +52,11 @@ pub enum CallBackId {
     Cb6, Cb7, Cb8, Cb9
 }
 
-pub struct Testbed<'a> {
+pub struct Testbed {
     world:     World<f32>,
     callbacks: [Option<Box<Fn(CallBackMode)>>; 9],
     window:    RenderWindow,
-    graphics:  GraphicsManager<'a>
+    graphics:  GraphicsManagerHandle,
 }
 
 struct TestbedState<'a> {
@@ -65,43 +65,45 @@ struct TestbedState<'a> {
     cb_states: [bool; 9],
     camera: Camera,
     fps: Fps<'a>,
-    grabbed_object: Option<Rc<RefCell<RigidBody<f32>>>>,
+    grabbed_object: Option<RigidBodyHandle<f32>>,
     grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>>,
 }
 
 impl<'a> TestbedState<'a> {
-    fn new(fnt: &'a Font) -> TestbedState<'a> {
+    fn new(fnt: &'a Font, rw: &RenderWindow) -> TestbedState<'a> {
         TestbedState{
-            running: RunMode::Running,
-            draw_colls: false,
-            cb_states: [ false; 9 ],
-            camera: Camera::new(),
-            fps: Fps::new(&fnt),
-            grabbed_object: None,
+            running:              RunMode::Running,
+            draw_colls:           false,
+            cb_states:            [ false; 9 ],
+            camera:               Camera::new(rw),
+            fps:                  Fps::new(&fnt),
+            grabbed_object:       None,
             grabbed_object_joint: None,
         }
     }
 }
 
-impl<'a> Testbed<'a> {
-    pub fn new_empty() -> Testbed<'a> {
-        let mode    = VideoMode::new_init(800, 600, 32);
+impl Testbed {
+    pub fn new_empty() -> Testbed {
+        let mode   = VideoMode::new_init(800, 600, 32);
         let window =
-            match RenderWindow::new(mode, "nphysics 2d demo", Close, &ContextSettings::default()) {
+            match RenderWindow::new(mode, "nphysics 2d demo", window_style::CLOSE, &ContextSettings::default()) {
                 Some(rwindow) => rwindow,
                 None          => panic!("Error on creating the sfml window.")
             };
-        let graphics = GraphicsManager::new();
-
         Testbed {
             world:     World::new(),
             callbacks: [ None, None, None, None, None, None, None, None, None ],
             window:    window,
-            graphics:  graphics
+            graphics:  Rc::new(RefCell::new(GraphicsManager::new()))
         }
     }
 
-    pub fn new(world: World<f32>) -> Testbed<'a> {
+    pub fn graphics(&self) -> GraphicsManagerHandle {
+        self.graphics.clone()
+    }
+
+    pub fn new(world: World<f32>) -> Testbed {
         let mut res = Testbed::new_empty();
 
         res.set_world(world);
@@ -110,22 +112,26 @@ impl<'a> Testbed<'a> {
     }
 
     pub fn set_world(&mut self, world: World<f32>) {
-        self.world = world;
-        self.graphics.clear();
+        let mut bgraphics = self.graphics.borrow_mut();
 
-        for rb in self.world.bodies() {
-            self.graphics.add(rb.clone());
+        self.world = world;
+        bgraphics.clear();
+
+        for rb in self.world.rigid_bodies() {
+            bgraphics.add(WorldObject::RigidBody(rb.clone()));
+        }
+
+        for s in self.world.sensors() {
+            bgraphics.add(WorldObject::Sensor(s.clone()));
         }
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
-        let color = Pnt3::new(
-            (color.x * 255.0) as u8,
-            (color.y * 255.0) as u8,
-            (color.z * 255.0) as u8
-        );
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+        self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+    }
 
-        self.graphics.set_color(body, color);
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+        self.graphics.borrow_mut().set_sensor_color(sensor, color);
     }
 
     pub fn add_callback(&mut self, id: CallBackId, callback: Box<Fn(CallBackMode)>) {
@@ -146,7 +152,7 @@ impl<'a> Testbed<'a> {
         let font_mem = include_bytes!("Inconsolata.otf");
         let     fnt  = Font::new_from_memory(font_mem).unwrap();
 
-        let mut state = TestbedState::new(&fnt);
+        let mut state = TestbedState::new(&fnt, &self.window);
 
         let mut args    = env::args();
 
@@ -182,7 +188,7 @@ impl<'a> Testbed<'a> {
 
             state.fps.register_delta();
 
-            self.graphics.draw(&mut self.window, &state.camera);
+            self.graphics.borrow_mut().draw(&mut self.window, &state.camera);
 
             state.camera.activate_scene(&mut self.window);
             self.draw_collisions(&mut state);
@@ -197,12 +203,12 @@ impl<'a> Testbed<'a> {
     fn process_events(&mut self, mut state: &mut TestbedState) {
         loop {
             match self.window.poll_event() {
-                event::KeyPressed{code, ..} => self.process_key_press(&mut state, code),
-                event::MouseButtonPressed{button, x, y} => self.process_mouse_press(&mut state, button, x, y),
-                event::MouseButtonReleased{button, x, y} => self.process_mouse_release(&mut state, button, x, y),
-                event::MouseMoved{x, y} => self.process_mouse_moved(&mut state, x, y),
-                event::Closed  => self.window.close(),
-                event::NoEvent => break,
+                Event::KeyPressed{code, ..} => self.process_key_press(&mut state, code),
+                Event::MouseButtonPressed{button, x, y} => self.process_mouse_press(&mut state, button, x, y),
+                Event::MouseButtonReleased{button, x, y} => self.process_mouse_release(&mut state, button, x, y),
+                Event::MouseMoved{x, y} => self.process_mouse_moved(&mut state, x, y),
+                Event::Closed  => self.window.close(),
+                Event::NoEvent => break,
                 e              => state.camera.handle_event(&e)
             }
         }
@@ -252,15 +258,18 @@ impl<'a> Testbed<'a> {
 
     fn process_mouse_press(&mut self, state: &mut TestbedState, button: MouseButton, x: i32, y: i32) {
         match button {
-            MouseButton::MouseLeft => {
+            MouseButton::Left => {
                 let mapped_coords = state.camera.map_pixel_to_coords(Vector2i::new(x, y));
                 let mapped_point = Pnt2::new(mapped_coords.x, mapped_coords.y);
+                // FIXME: use the collision groups to filter out sensors.
                 let all_groups = &CollisionGroups::new();
                 for b in self.world
                              .collision_world()
                              .interferences_with_point(&mapped_point, all_groups) {
-                    if b.data.borrow().can_move() {
-                        state.grabbed_object = Some(b.data.clone())
+                    if let &WorldObject::RigidBody(ref rb) = &b.data {
+                        if rb.borrow().can_move() {
+                            state.grabbed_object = Some(rb.clone())
+                        }
                     }
                 }
 
@@ -279,7 +288,7 @@ impl<'a> Testbed<'a> {
                         let joint = Fixed::new(anchor1, anchor2);
                         state.grabbed_object_joint = Some(self.world.add_fixed(joint));
 
-                        for node in self.graphics.body_to_scene_node(b).unwrap().iter_mut() {
+                        for node in self.graphics.borrow_mut().rigid_body_to_scene_node(b).unwrap().iter_mut() {
                             node.select()
                         }
                     },
@@ -287,17 +296,17 @@ impl<'a> Testbed<'a> {
                 }
             },
             _ => {
-                state.camera.handle_event(&event::MouseButtonPressed{ button: button, x: x, y: y })
+                state.camera.handle_event(&Event::MouseButtonPressed { button: button, x: x, y: y })
             }
         }
     }
 
     fn process_mouse_release(&mut self, state: &mut TestbedState, button: MouseButton, x: i32, y: i32) {
         match button {
-            MouseButton::MouseLeft => {
+            MouseButton::Left => {
                 match state.grabbed_object {
                     Some(ref b) => {
-                        for node in self.graphics.body_to_scene_node(b).unwrap().iter_mut() {
+                        for node in self.graphics.borrow_mut().rigid_body_to_scene_node(b).unwrap().iter_mut() {
                             node.unselect()
                         }
                     },
@@ -313,7 +322,7 @@ impl<'a> Testbed<'a> {
                 state.grabbed_object_joint = None;
             },
             _ => {
-                state.camera.handle_event(&event::MouseButtonReleased{ button: button, x: x, y: y })
+                state.camera.handle_event(&Event::MouseButtonReleased { button: button, x: x, y: y })
             }
         }
     }
@@ -328,7 +337,7 @@ impl<'a> Testbed<'a> {
                 let joint = state.grabbed_object_joint.as_ref().unwrap();
                 joint.borrow_mut().set_local2(attach2);
             },
-            None => state.camera.handle_event(&event::MouseMoved{x: x, y: y})
+            None => state.camera.handle_event(&Event::MouseMoved {x: x, y: y})
         };
     }
 

--- a/examples2d/nphysics_testbed2d/src/testbed.rs
+++ b/examples2d/nphysics_testbed2d/src/testbed.rs
@@ -8,7 +8,7 @@ use sfml::window::event::Event;
 use sfml::window::{Key, MouseButton};
 use sfml::graphics::Color;
 use sfml::system::Vector2i;
-use na::{Pnt2, Pnt3, Iso2};
+use na::{Point2, Point3, Isometry2};
 use na;
 use ncollide::world::CollisionGroups;
 use nphysics2d::world::World;
@@ -126,11 +126,11 @@ impl Testbed {
         }
     }
 
-    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
         self.graphics.borrow_mut().set_rigid_body_color(rb, color);
     }
 
-    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
         self.graphics.borrow_mut().set_sensor_color(sensor, color);
     }
 
@@ -260,7 +260,7 @@ impl Testbed {
         match button {
             MouseButton::Left => {
                 let mapped_coords = state.camera.map_pixel_to_coords(Vector2i::new(x, y));
-                let mapped_point = Pnt2::new(mapped_coords.x, mapped_coords.y);
+                let mapped_point = Point2::new(mapped_coords.x, mapped_coords.y);
                 // FIXME: use the collision groups to filter out sensors.
                 let all_groups = &CollisionGroups::new();
                 for b in self.world
@@ -280,9 +280,9 @@ impl Testbed {
                             None        => { }
                         }
 
-                        let _1: Iso2<f32> = na::one();
-                        let attach2 = na::append_translation(&_1, mapped_point.as_vec());
-                        let attach1 = na::inv(&na::transformation(b.borrow().position())).unwrap() * attach2;
+                        let _1: Isometry2<f32> = na::one();
+                        let attach2 = na::append_translation(&_1, mapped_point.as_vector());
+                        let attach1 = na::inverse(&na::transformation(b.borrow().position())).unwrap() * attach2;
                         let anchor1 = Anchor::new(Some(state.grabbed_object.as_ref().unwrap().clone()), attach1);
                         let anchor2 = Anchor::new(None, attach2);
                         let joint = Fixed::new(anchor1, anchor2);
@@ -329,9 +329,9 @@ impl Testbed {
 
     fn process_mouse_moved(&mut self, state: &mut TestbedState, x: i32, y: i32) {
         let mapped_coords = state.camera.map_pixel_to_coords(Vector2i::new(x, y));
-        let mapped_point = Pnt2::new(mapped_coords.x, mapped_coords.y);
-        let _1: Iso2<f32> = na::one();
-        let attach2 = na::append_translation(&_1, (mapped_point).as_vec());
+        let mapped_point = Point2::new(mapped_coords.x, mapped_coords.y);
+        let _1: Isometry2<f32> = na::one();
+        let attach2 = na::append_translation(&_1, (mapped_point).as_vector());
         match state.grabbed_object {
             Some(_) => {
                 let joint = state.grabbed_object_joint.as_ref().unwrap();

--- a/examples2d/pyramid.rs
+++ b/examples2d/pyramid.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, -1.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector2::new(0.0, -1.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -38,9 +38,9 @@ fn main() {
             let x = (fi * shift / 2.0) + (fj - fi) * 2.5 * rad - centerx;
             let y = -fi * 2.5 * rad - 0.04 - rad;
 
-            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
+            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector2::new(rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/pyramid.rs
+++ b/examples2d/pyramid.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, -1.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -42,7 +42,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples2d/ragdoll.rs
+++ b/examples2d/ragdoll.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Pnt2, Vec1, Vec2, Translation, Rotation, BaseFloat};
+use na::{Point2, Vector1, Vector2, Translation, Rotation, BaseFloat};
 use ncollide::shape::{Plane, Cuboid, Ball};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -15,12 +15,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * A plane for the ground
      */
-    let ground_geom = Plane::new(Vec2::new(0.0, -1.0));
+    let ground_geom = Plane::new(Vector2::new(0.0, -1.0));
 
     world.add_rigid_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
 
@@ -35,7 +35,7 @@ fn main() {
             let x = i as f32 * shift - n as f32 * shift / 2.0;
             let y = j as f32 * (-shift) - 10.0;
 
-            add_ragdoll(Vec2::new(x, y), &mut world);
+            add_ragdoll(Vector2::new(x, y), &mut world);
         }
     }
 
@@ -47,36 +47,36 @@ fn main() {
     testbed.run();
 }
 
-fn add_ragdoll(pos: Vec2<f32>, world: &mut World<f32>) {
+fn add_ragdoll(pos: Vector2<f32>, world: &mut World<f32>) {
     // head
     let     head_geom = Ball::new(0.8);
     let mut head      = RigidBody::new_dynamic(head_geom, 1.0, 0.3, 0.5);
-    head.append_translation(&(pos + Vec2::new(0.0, -2.4)));
+    head.append_translation(&(pos + Vector2::new(0.0, -2.4)));
 
     // body
-    let     body_geom = Cuboid::new(Vec2::new(1.2, 0.5));
+    let     body_geom = Cuboid::new(Vector2::new(1.2, 0.5));
     let mut body      = RigidBody::new_dynamic(body_geom, 1.0, 0.3, 0.5);
-    body.append_rotation(&-Vec1::new(BaseFloat::frac_pi_2()));
+    body.append_rotation(&-Vector1::new(BaseFloat::frac_pi_2()));
     body.append_translation(&pos);
 
     // right arm
-    let     rarm_geom = Cuboid::new(Vec2::new(1.6, 0.2));
+    let     rarm_geom = Cuboid::new(Vector2::new(1.6, 0.2));
     let mut rarm      = RigidBody::new_dynamic(rarm_geom, 1.0, 0.3, 0.5);
-    rarm.append_translation(&(pos + Vec2::new(2.4, -1.0)));
+    rarm.append_translation(&(pos + Vector2::new(2.4, -1.0)));
 
     // left arm
     let mut larm      = rarm.clone();
-    larm.append_translation(&Vec2::new(-4.8, 0.0));
+    larm.append_translation(&Vector2::new(-4.8, 0.0));
 
     // right foot
-    let     rfoot_geom = Cuboid::new(Vec2::new(1.6, 0.2));
+    let     rfoot_geom = Cuboid::new(Vector2::new(1.6, 0.2));
     let mut rfoot      = RigidBody::new_dynamic(rfoot_geom, 1.0, 0.3, 0.5);
-    rfoot.append_rotation(&-Vec1::new(BaseFloat::frac_pi_2()));
-    rfoot.append_translation(&(pos + Vec2::new(0.4, 3.0)));
+    rfoot.append_rotation(&-Vector1::new(BaseFloat::frac_pi_2()));
+    rfoot.append_translation(&(pos + Vector2::new(0.4, 3.0)));
 
     // left foot
     let mut lfoot      = rfoot.clone();
-    lfoot.append_translation(&Vec2::new(-0.8, 0.0));
+    lfoot.append_translation(&Vector2::new(-0.8, 0.0));
 
     let head  = world.add_rigid_body(head);
     let body  = world.add_rigid_body(body);
@@ -88,17 +88,17 @@ fn add_ragdoll(pos: Vec2<f32>, world: &mut World<f32>) {
     /*
      * Create joints.
      */
-    let body_anchor_head  = Anchor::new(Some(body.clone()), Pnt2::new(1.4, 0.0));
-    let body_anchor_rarm  = Anchor::new(Some(body.clone()), Pnt2::new(1.0, 0.76));
-    let body_anchor_larm  = Anchor::new(Some(body.clone()), Pnt2::new(1.0, -0.76));
-    let body_anchor_rfoot = Anchor::new(Some(body.clone()), Pnt2::new(-1.5, 0.3));
-    let body_anchor_lfoot = Anchor::new(Some(body.clone()), Pnt2::new(-1.5, -0.3));
+    let body_anchor_head  = Anchor::new(Some(body.clone()), Point2::new(1.4, 0.0));
+    let body_anchor_rarm  = Anchor::new(Some(body.clone()), Point2::new(1.0, 0.76));
+    let body_anchor_larm  = Anchor::new(Some(body.clone()), Point2::new(1.0, -0.76));
+    let body_anchor_rfoot = Anchor::new(Some(body.clone()), Point2::new(-1.5, 0.3));
+    let body_anchor_lfoot = Anchor::new(Some(body.clone()), Point2::new(-1.5, -0.3));
 
-    let head_anchor       = Anchor::new(Some(head), Pnt2::new(0.0, 0.9));
-    let rarm_anchor       = Anchor::new(Some(rarm), Pnt2::new(-1.5, 0.0));
-    let larm_anchor       = Anchor::new(Some(larm), Pnt2::new(1.5, 0.0));
-    let rfoot_anchor      = Anchor::new(Some(rfoot), Pnt2::new(1.5, 0.0));
-    let lfoot_anchor      = Anchor::new(Some(lfoot), Pnt2::new(1.5, 0.0));
+    let head_anchor       = Anchor::new(Some(head), Point2::new(0.0, 0.9));
+    let rarm_anchor       = Anchor::new(Some(rarm), Point2::new(-1.5, 0.0));
+    let larm_anchor       = Anchor::new(Some(larm), Point2::new(1.5, 0.0));
+    let rfoot_anchor      = Anchor::new(Some(rfoot), Point2::new(1.5, 0.0));
+    let lfoot_anchor      = Anchor::new(Some(lfoot), Point2::new(1.5, 0.0));
 
     let head_joint  = BallInSocket::new(body_anchor_head,   head_anchor);
     let rarm_joint  = BallInSocket::new(body_anchor_rarm,   rarm_anchor);

--- a/examples2d/ragdoll.rs
+++ b/examples2d/ragdoll.rs
@@ -22,7 +22,7 @@ fn main() {
      */
     let ground_geom = Plane::new(Vec2::new(0.0, -1.0));
 
-    world.add_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
 
     /*
      * Create the ragdolls
@@ -78,12 +78,12 @@ fn add_ragdoll(pos: Vec2<f32>, world: &mut World<f32>) {
     let mut lfoot      = rfoot.clone();
     lfoot.append_translation(&Vec2::new(-0.8, 0.0));
 
-    let head  = world.add_body(head);
-    let body  = world.add_body(body);
-    let rarm  = world.add_body(rarm);
-    let larm  = world.add_body(larm);
-    let rfoot = world.add_body(rfoot);
-    let lfoot = world.add_body(lfoot);
+    let head  = world.add_rigid_body(head);
+    let body  = world.add_rigid_body(body);
+    let rarm  = world.add_rigid_body(rarm);
+    let larm  = world.add_rigid_body(larm);
+    let rfoot = world.add_rigid_body(rfoot);
+    let lfoot = world.add_rigid_body(lfoot);
 
     /*
      * Create joints.

--- a/examples2d/sensor.rs
+++ b/examples2d/sensor.rs
@@ -1,0 +1,100 @@
+extern crate nalgebra as na;
+extern crate ncollide;
+extern crate nphysics2d;
+extern crate nphysics_testbed2d;
+
+use na::{Vec2, Pnt3, Translation};
+use ncollide::shape::{Plane, Cuboid, Ball};
+use ncollide::geometry::Proximity;
+use ncollide::narrow_phase::ProximitySignalHandler;
+use nphysics2d::world::World;
+use nphysics2d::object::{RigidBody, WorldObject};
+use nphysics2d::object::Sensor;
+use nphysics_testbed2d::{Testbed, GraphicsManagerHandle};
+
+/*
+ * A proximity handler that will change the color of a rigid body as it enters of leaves proximity
+ * with the sensor.
+ */
+struct ColorChanger {
+    graphics: GraphicsManagerHandle
+}
+
+impl ProximitySignalHandler<WorldObject<f32>> for ColorChanger {
+    fn handle_proximity(&mut self,
+                        o1: &WorldObject<f32>, o2: &WorldObject<f32>,
+                        _: Proximity, new_proximity: Proximity) {
+        let color = match new_proximity {
+            Proximity::WithinMargin | Proximity::Intersecting => Pnt3::new(1.0, 1.0, 0.0),
+            Proximity::Disjoint                               => Pnt3::new(0.5, 0.5, 1.0)
+        };
+    
+        if let WorldObject::RigidBody(ref rb) = *o1 {
+            self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+        }
+    
+        if let WorldObject::RigidBody(ref rb) = *o2 {
+            self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+        }
+    }
+}
+
+fn main() {
+    let mut testbed = Testbed::new_empty();
+
+    /*
+     * World
+     */
+    let mut world = World::new();
+    world.set_gravity(Vec2::new(0.0, 9.81));
+
+    /*
+     * Plane
+     */
+    let geom = Plane::new(Vec2::new(0.0, -1.0));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.2, 0.6));
+
+    /*
+     * Create some boxes.
+     */
+    let num     = 15;
+    let rad     = 1.0;
+    let shift   = rad * 2.0;
+    let centerx = shift * (num as f32) / 2.0;
+
+    for i in 0usize .. num {
+        let x = i as f32 * shift - centerx;
+
+        let geom   = Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04));
+        let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.2, 0.5);
+
+        rb.append_translation(&Vec2::new(x, -1.0));
+
+        let rb_handle = world.add_rigid_body(rb);
+        testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 0.5, 1.0));
+    }
+
+    /*
+     * Create a box that will have a sensor attached.
+     */
+    let geom   = Cuboid::new(Vec2::new(0.5f32, 0.5));
+    let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.2, 0.5);
+    rb.append_translation(&Vec2::new(0.0, -10.0));
+    let rb_handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 1.0, 1.0));
+
+    // Attach a sensor.
+    let sensor_geom = Ball::new(rad * 5.0);
+    let sensor      = Sensor::new(sensor_geom, Some(rb_handle));
+    world.add_sensor(sensor);
+
+    // Setup the callback.
+    let handler = ColorChanger { graphics: testbed.graphics() };
+    world.register_proximity_signal_handler("color_changer", handler);
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(world);
+    testbed.run();
+}

--- a/examples2d/sensor.rs
+++ b/examples2d/sensor.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Vec2, Pnt3, Translation};
+use na::{Vector2, Point3, Translation};
 use ncollide::shape::{Plane, Cuboid, Ball};
 use ncollide::geometry::Proximity;
 use ncollide::narrow_phase::ProximitySignalHandler;
@@ -25,8 +25,8 @@ impl ProximitySignalHandler<WorldObject<f32>> for ColorChanger {
                         o1: &WorldObject<f32>, o2: &WorldObject<f32>,
                         _: Proximity, new_proximity: Proximity) {
         let color = match new_proximity {
-            Proximity::WithinMargin | Proximity::Intersecting => Pnt3::new(1.0, 1.0, 0.0),
-            Proximity::Disjoint                               => Pnt3::new(0.5, 0.5, 1.0)
+            Proximity::WithinMargin | Proximity::Intersecting => Point3::new(1.0, 1.0, 0.0),
+            Proximity::Disjoint                               => Point3::new(0.5, 0.5, 1.0)
         };
     
         if let WorldObject::RigidBody(ref rb) = *o1 {
@@ -46,12 +46,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec2::new(0.0, -1.0));
+    let geom = Plane::new(Vector2::new(0.0, -1.0));
     world.add_rigid_body(RigidBody::new_static(geom, 0.2, 0.6));
 
     /*
@@ -65,23 +65,23 @@ fn main() {
     for i in 0usize .. num {
         let x = i as f32 * shift - centerx;
 
-        let geom   = Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04));
+        let geom   = Cuboid::new(Vector2::new(rad - 0.04, rad - 0.04));
         let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.2, 0.5);
 
-        rb.append_translation(&Vec2::new(x, -1.0));
+        rb.append_translation(&Vector2::new(x, -1.0));
 
         let rb_handle = world.add_rigid_body(rb);
-        testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 0.5, 1.0));
+        testbed.set_rigid_body_color(&rb_handle, Point3::new(0.5, 0.5, 1.0));
     }
 
     /*
      * Create a box that will have a sensor attached.
      */
-    let geom   = Cuboid::new(Vec2::new(0.5f32, 0.5));
+    let geom   = Cuboid::new(Vector2::new(0.5f32, 0.5));
     let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.2, 0.5);
-    rb.append_translation(&Vec2::new(0.0, -10.0));
+    rb.append_translation(&Vector2::new(0.0, -10.0));
     let rb_handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 1.0, 1.0));
+    testbed.set_rigid_body_color(&rb_handle, Point3::new(0.5, 1.0, 1.0));
 
     // Attach a sensor.
     let sensor_geom = Ball::new(rad * 5.0);

--- a/examples2d/wall.rs
+++ b/examples2d/wall.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics2d;
 extern crate nphysics_testbed2d;
 
-use na::{Vec2, Translation};
+use na::{Vector2, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics2d::world::World;
 use nphysics2d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec2::new(0.0, 9.81));
+    world.set_gravity(Vector2::new(0.0, 9.81));
 
     /*
      * First plane
      */
-    let rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, -1.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector2::new(0.0, -1.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -39,9 +39,9 @@ fn main() {
             let x  = fj * 2.0 * rad - centerx;
             let y  = -fi * 2.0 * rad - 0.04 - rad;
 
-            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec2::new(rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
+            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector2::new(rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec2::new(x, y));
+            rb.append_translation(&Vector2::new(x, y));
 
             world.add_rigid_body(rb);
         }

--- a/examples2d/wall.rs
+++ b/examples2d/wall.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec2::new(0.0, -1.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -43,7 +43,7 @@ fn main() {
 
             rb.append_translation(&Vec2::new(x, y));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -65,6 +65,10 @@ name = "convex_decomposition"
 path = "./convex_decomposition.rs"
 
 [[bin]]
+name = "collision_groups"
+path = "./collision_groups.rs"
+
+[[bin]]
 name = "sensor"
 path = "./sensor.rs"
 

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -65,6 +65,10 @@ name = "convex_decomposition"
 path = "./convex_decomposition.rs"
 
 [[bin]]
+name = "sensor"
+path = "./sensor.rs"
+
+[[bin]]
 name = "fixed_bug_long_thin_box_one_shot_manifold"
 path = "fixed_bug_long_thin_box_one_shot_manifold.rs"
 

--- a/examples3d/balls_vee.rs
+++ b/examples3d/balls_vee.rs
@@ -30,7 +30,7 @@ fn main() {
     for n in normals.iter() {
         let rb   = RigidBody::new_static(Plane::new(*n), 0.3, 0.6);
 
-        world.add_body(rb);
+        world.add_rigid_body(rb);
     }
 
     /*
@@ -53,7 +53,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/balls_vee.rs
+++ b/examples3d/balls_vee.rs
@@ -5,7 +5,7 @@ extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
 use num::Float;
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Ball, Plane};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -16,16 +16,16 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
     let normals = [
-        Vec3::new(-1.0, 1.0, -1.0 ),
-        Vec3::new(1.0, 1.0, -1.0 ),
-        Vec3::new(-1.0, 1.0, 1.0 ),
-        Vec3::new(1.0, 1.0, 1.0 )
+        Vector3::new(-1.0, 1.0, -1.0 ),
+        Vector3::new(1.0, 1.0, -1.0 ),
+        Vector3::new(-1.0, 1.0, 1.0 ),
+        Vector3::new(1.0, 1.0, 1.0 )
     ];
     for n in normals.iter() {
         let rb   = RigidBody::new_static(Plane::new(*n), 0.3, 0.6);
@@ -51,7 +51,7 @@ fn main() {
 
                 let mut rb = RigidBody::new_dynamic(Ball::new(rad), 1.0, 0.3, 0.6);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -63,6 +63,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-10.0, 50.0, -10.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-10.0, 50.0, -10.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/boxes_vee.rs
+++ b/examples3d/boxes_vee.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * Create the boxes
@@ -45,7 +45,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/boxes_vee.rs
+++ b/examples3d/boxes_vee.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
@@ -40,10 +40,10 @@ fn main() {
                 let y = j as f32 * shift + centery;
                 let z = k as f32 * shift - centerz;
 
-                let geom   = Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04));
+                let geom   = Cuboid::new(Vector3::new(rad - 0.04, rad - 0.04, rad - 0.04));
                 let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -55,6 +55,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/collision_groups.rs
+++ b/examples3d/collision_groups.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::{RigidBody, RigidBodyCollisionGroups};
@@ -16,7 +16,7 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Setup groups.
@@ -43,32 +43,32 @@ fn main() {
     /*
      * A floor that will collide with everything (default behaviour).
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * A green floor that will collide with the GREEN group only.
      */
-    let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
+    let geom   = Cuboid::new(Vector3::new(10.0, 1.0, 10.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
     rb.set_collision_groups(green_static_group);
-    rb.append_translation(&Vec3::new(0.0, 10.0, 0.0));
+    rb.append_translation(&Vector3::new(0.0, 10.0, 0.0));
 
     let handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 1.0, 0.0));
 
     /*
      * A blue floor that will collide with the BLUE group only.
      */
-    let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
+    let geom   = Cuboid::new(Vector3::new(10.0, 1.0, 10.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
     rb.set_collision_groups(blue_static_group);
-    rb.append_translation(&Vec3::new(0.0, 20.0, 0.0));
+    rb.append_translation(&Vector3::new(0.0, 20.0, 0.0));
 
     let handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 0.0, 1.0));
 
     /*
      * Create the boxes
@@ -87,21 +87,21 @@ fn main() {
                 let z = j as f32 * shift - centerz;
                 let y = k as f32 * shift + centery;
 
-                let geom   = Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04));
+                let geom   = Cuboid::new(Vector3::new(rad - 0.04, rad - 0.04, rad - 0.04));
                 let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 // Alternate between the GREEN and BLUE groups.
                 if k % 2 == 0 {
                     rb.set_collision_groups(green_dynamic_group);
                     let handle = world.add_rigid_body(rb);
-                    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+                    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 1.0, 0.0));
                 }
                 else {
                     rb.set_collision_groups(blue_dynamic_group);
                     let handle = world.add_rigid_body(rb);
-                    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+                    testbed.set_rigid_body_color(&handle, Point3::new(0.0, 0.0, 1.0));
                 }
             }
         }
@@ -111,6 +111,6 @@ fn main() {
      * Set up the testbed.
      */
     testbed.set_world(world);
-    testbed.look_at(Pnt3::new(-40.0, 40.0, -40.0), Pnt3::new(0.0, 3.0, 0.0));
+    testbed.look_at(Point3::new(-40.0, 40.0, -40.0), Point3::new(0.0, 3.0, 0.0));
     testbed.run();
 }

--- a/examples3d/collision_groups.rs
+++ b/examples3d/collision_groups.rs
@@ -19,7 +19,7 @@ fn main() {
     world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
 
     /*
-     * Declare groups.
+     * Setup groups.
      */
     const GREEN_GROUP_ID: usize = 0;
     let mut green_static_group  = RigidBodyCollisionGroups::new_static();
@@ -47,7 +47,7 @@ fn main() {
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
-     * A green floor that will collide with the BLUE group only.
+     * A green floor that will collide with the GREEN group only.
      */
     let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
@@ -59,7 +59,7 @@ fn main() {
     testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
 
     /*
-     * A blue floor that will collide with the GREEN group only.
+     * A blue floor that will collide with the BLUE group only.
      */
     let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);

--- a/examples3d/collision_groups.rs
+++ b/examples3d/collision_groups.rs
@@ -1,0 +1,116 @@
+extern crate nalgebra as na;
+extern crate ncollide;
+extern crate nphysics3d;
+extern crate nphysics_testbed3d;
+
+use na::{Pnt3, Vec3, Translation};
+use ncollide::shape::{Plane, Cuboid};
+use nphysics3d::world::World;
+use nphysics3d::object::{RigidBody, RigidBodyCollisionGroups};
+use nphysics_testbed3d::Testbed;
+
+fn main() {
+    let mut testbed = Testbed::new_empty();
+
+    /*
+     * World
+     */
+    let mut world = World::new();
+    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+
+    /*
+     * Declare groups.
+     */
+    const GREEN_GROUP_ID: usize = 0;
+    let mut green_static_group  = RigidBodyCollisionGroups::new_static();
+    green_static_group.set_membership(&[ GREEN_GROUP_ID ]);
+    green_static_group.set_whitelist(&[ GREEN_GROUP_ID ]);
+
+    let mut green_dynamic_group = RigidBodyCollisionGroups::new_dynamic();
+    green_dynamic_group.set_membership(&[ GREEN_GROUP_ID ]);
+    green_dynamic_group.set_whitelist(&[ GREEN_GROUP_ID ]);
+
+
+    const BLUE_GROUP_ID: usize = 1;
+    let mut blue_static_group = RigidBodyCollisionGroups::new_static();
+    blue_static_group.set_membership(&[ BLUE_GROUP_ID ]);
+    blue_static_group.set_whitelist(&[ BLUE_GROUP_ID ]);
+
+    let mut blue_dynamic_group = RigidBodyCollisionGroups::new_dynamic();
+    blue_dynamic_group.set_membership(&[ BLUE_GROUP_ID ]);
+    blue_dynamic_group.set_whitelist(&[ BLUE_GROUP_ID ]);
+
+    /*
+     * A floor that will collide with everything (default behaviour).
+     */
+    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
+
+    /*
+     * A green floor that will collide with the BLUE group only.
+     */
+    let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
+    let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
+
+    rb.set_collision_groups(green_static_group);
+    rb.append_translation(&Vec3::new(0.0, 10.0, 0.0));
+
+    let handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+
+    /*
+     * A blue floor that will collide with the GREEN group only.
+     */
+    let geom   = Cuboid::new(Vec3::new(10.0, 1.0, 10.0));
+    let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
+
+    rb.set_collision_groups(blue_static_group);
+    rb.append_translation(&Vec3::new(0.0, 20.0, 0.0));
+
+    let handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+
+    /*
+     * Create the boxes
+     */
+    let num     = 8;
+    let rad     = 1.0;
+    let shift   = rad * 2.0;
+    let centerx = shift * (num as f32) / 2.0;
+    let centery = 25.0;
+    let centerz = shift * (num as f32) / 2.0;
+
+    for k in 0usize .. 4 {
+        for i in 0usize .. num {
+            for j in 0usize .. num {
+                let x = i as f32 * shift - centerx;
+                let z = j as f32 * shift - centerz;
+                let y = k as f32 * shift + centery;
+
+                let geom   = Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04));
+                let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
+
+                rb.append_translation(&Vec3::new(x, y, z));
+
+                // Alternate between the GREEN and BLUE groups.
+                if k % 2 == 0 {
+                    rb.set_collision_groups(green_dynamic_group);
+                    let handle = world.add_rigid_body(rb);
+                    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 1.0, 0.0));
+                }
+                else {
+                    rb.set_collision_groups(blue_dynamic_group);
+                    let handle = world.add_rigid_body(rb);
+                    testbed.set_rigid_body_color(&handle, Pnt3::new(0.0, 0.0, 1.0));
+                }
+            }
+        }
+    }
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(world);
+    testbed.look_at(Pnt3::new(-40.0, 40.0, -40.0), Pnt3::new(0.0, 3.0, 0.0));
+    testbed.run();
+}

--- a/examples3d/compound.rs
+++ b/examples3d/compound.rs
@@ -24,7 +24,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
@@ -66,7 +66,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/compound.rs
+++ b/examples3d/compound.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Iso3, Translation};
+use na::{Point3, Vector3, Isometry3, Translation};
 use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics3d::volumetric::Volumetric;
 use nphysics3d::world::World;
@@ -15,25 +15,25 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
      */
-    let delta1 = Iso3::new(Vec3::new(0.0, -5.0, 0.0), na::zero());
-    let delta2 = Iso3::new(Vec3::new(-5.0, 0.0, 0.0), na::zero());
-    let delta3 = Iso3::new(Vec3::new(5.0, 0.0, 0.0), na::zero());
+    let delta1 = Isometry3::new(Vector3::new(0.0, -5.0, 0.0), na::zero());
+    let delta2 = Isometry3::new(Vector3::new(-5.0, 0.0, 0.0), na::zero());
+    let delta3 = Isometry3::new(Vector3::new(5.0, 0.0, 0.0), na::zero());
 
     let mut cross_geoms = Vec::new();
-    let vertical   = ShapeHandle::new(Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21)));
-    let horizontal = ShapeHandle::new(Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21)));
+    let vertical   = ShapeHandle::new(Cuboid::new(Vector3::new(0.21f32, 4.96, 0.21)));
+    let horizontal = ShapeHandle::new(Cuboid::new(Vector3::new(4.96f32, 0.21, 0.21)));
     cross_geoms.push((delta1, horizontal));
     cross_geoms.push((delta2, vertical.clone()));
     cross_geoms.push((delta3, vertical));
@@ -61,7 +61,7 @@ fn main() {
 
                 let mut rb = RigidBody::new(cross.clone(), Some(mass), 0.3, 0.5);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -73,6 +73,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/compound.rs
+++ b/examples3d/compound.rs
@@ -3,10 +3,8 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use std::sync::Arc;
 use na::{Pnt3, Vec3, Iso3, Translation};
-use ncollide::shape::{Plane, Cuboid, Compound};
-use ncollide::inspection::Repr3;
+use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics3d::volumetric::Volumetric;
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -34,16 +32,15 @@ fn main() {
     let delta3 = Iso3::new(Vec3::new(5.0, 0.0, 0.0), na::zero());
 
     let mut cross_geoms = Vec::new();
-    let vertical   = Arc::new(Box::new(Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21))) as Box<Repr3<f32>>);
-    let horizontal = Arc::new(Box::new(Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21))) as Box<Repr3<f32>>);
+    let vertical   = ShapeHandle::new(Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21)));
+    let horizontal = ShapeHandle::new(Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21)));
     cross_geoms.push((delta1, horizontal));
     cross_geoms.push((delta2, vertical.clone()));
     cross_geoms.push((delta3, vertical));
 
     let compound = Compound::new(cross_geoms);
     let mass     = compound.mass_properties(1.0);
-    let cross    = Box::new(compound) as Box<Repr3<f32>>;
-    let cross    = Arc::new(cross);
+    let cross    = ShapeHandle::new(compound);
 
     /*
      * Create the crosses

--- a/examples3d/convex.rs
+++ b/examples3d/convex.rs
@@ -5,8 +5,8 @@ extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
 use rand::random;
-use na::{Pnt3, Vec3, Translation};
-use ncollide::shape::{Plane, Convex};
+use na::{Point3, Vector3, Translation};
+use ncollide::shape::{Plane, ConvexHull};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
 use nphysics_testbed3d::Testbed;
@@ -16,12 +16,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
@@ -45,13 +45,13 @@ fn main() {
                 let mut pts = Vec::with_capacity(npts);
 
                 for _ in 0 .. npts {
-                    pts.push(random::<Pnt3<f32>>() * 2.0+ Vec3::new(5.0, 5.0, 5.0));
+                    pts.push(random::<Point3<f32>>() * 2.0 + Vector3::new(5.0, 5.0, 5.0));
                 }
 
-                let geom = Convex::new(pts);
+                let geom = ConvexHull::new(pts);
                 let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -63,6 +63,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/convex.rs
+++ b/examples3d/convex.rs
@@ -23,7 +23,7 @@ fn main() {
      */
     let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * Create the convex geometries.
@@ -53,7 +53,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/convex_decomposition.rs
+++ b/examples3d/convex_decomposition.rs
@@ -53,7 +53,7 @@ fn main() {
 
         rb.append_translation(pos);
 
-        world.add_body(rb);
+        world.add_rigid_body(rb);
     }
 
     /*
@@ -125,7 +125,7 @@ fn main() {
             let pos = random::<Vec3<f32>>() * 30.0+ Vec3::new(-15.0, 15.0, -15.0);
             rb.append_translation(&pos);
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples3d/convex_decomposition.rs
+++ b/examples3d/convex_decomposition.rs
@@ -5,17 +5,15 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use std::sync::Arc;
 use std::path::Path;
 use rand::random;
 use na::{Pnt3, Vec3, Translation};
 use kiss3d::loader::obj;
-use ncollide::shape::{Plane, Compound, Convex};
+use ncollide::shape::{Plane, Compound, Convex, ShapeHandle};
 use ncollide::procedural::TriMesh3;
 use ncollide::transformation;
 use ncollide::bounding_volume::{BoundingVolume, AABB};
 use ncollide::bounding_volume;
-use ncollide::inspection::Repr3;
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
 use nphysics_testbed3d::Testbed;
@@ -96,7 +94,7 @@ fn main() {
                 let (decomp, _) = transformation::hacd(trimesh, 0.03, 1);
 
                 for mesh in decomp.into_iter() {
-                    let convex = Arc::new(Box::new(Convex::new(mesh.coords)) as Box<Repr3<f32>>);
+                    let convex = ShapeHandle::new(Convex::new(mesh.coords));
                     geom_data.push((deltas, convex));
                 }
             }

--- a/examples3d/convex_decomposition.rs
+++ b/examples3d/convex_decomposition.rs
@@ -7,9 +7,9 @@ extern crate nphysics_testbed3d;
 
 use std::path::Path;
 use rand::random;
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use kiss3d::loader::obj;
-use ncollide::shape::{Plane, Compound, Convex, ShapeHandle};
+use ncollide::shape::{Plane, Compound, ConvexHull, ShapeHandle};
 use ncollide::procedural::TriMesh3;
 use ncollide::transformation;
 use ncollide::bounding_volume::{BoundingVolume, AABB};
@@ -23,7 +23,7 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
@@ -31,18 +31,18 @@ fn main() {
     let shift = 10.0;
 
     let normals = [
-        Vec3::new(0.0, 1.0, 0.0),
-        Vec3::new(-1.0, 1.0, 0.0),
-        Vec3::new(1.0, 1.0, 0.0),
-        Vec3::new(0.0, 1.0, -1.0),
-        Vec3::new(0.0, 1.0, 1.0),
+        Vector3::new(0.0, 1.0, 0.0),
+        Vector3::new(-1.0, 1.0, 0.0),
+        Vector3::new(1.0, 1.0, 0.0),
+        Vector3::new(0.0, 1.0, -1.0),
+        Vector3::new(0.0, 1.0, 1.0),
     ];
     let poss = [
-        Vec3::new(0.0, 0.0, 0.0),
-        Vec3::new(shift, 0.0, 0.0),
-        Vec3::new(-shift, 0.0, 0.0),
-        Vec3::new(0.0, 0.0, shift),
-        Vec3::new(0.0, 0.0, -shift)
+        Vector3::new(0.0, 0.0, 0.0),
+        Vector3::new(shift, 0.0, 0.0),
+        Vector3::new(-shift, 0.0, 0.0),
+        Vector3::new(0.0, 0.0, shift),
+        Vector3::new(0.0, 0.0, -shift)
     ];
 
     for (normal, pos) in normals.iter().zip(poss.iter()) {
@@ -94,7 +94,7 @@ fn main() {
                 let (decomp, _) = transformation::hacd(trimesh, 0.03, 1);
 
                 for mesh in decomp.into_iter() {
-                    let convex = ShapeHandle::new(Convex::new(mesh.coords));
+                    let convex = ShapeHandle::new(ConvexHull::new(mesh.coords));
                     geom_data.push((deltas, convex));
                 }
             }
@@ -120,7 +120,7 @@ fn main() {
     for rb in bodies.iter() {
         for _ in 0 .. nreplicats {
             let mut rb = rb.clone();
-            let pos = random::<Vec3<f32>>() * 30.0+ Vec3::new(-15.0, 15.0, -15.0);
+            let pos = random::<Vector3<f32>>() * 30.0+ Vector3::new(-15.0, 15.0, -15.0);
             rb.append_translation(&pos);
 
             world.add_rigid_body(rb);
@@ -132,7 +132,7 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }
 

--- a/examples3d/cross.rs
+++ b/examples3d/cross.rs
@@ -24,7 +24,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Cross shaped geometry
@@ -64,7 +64,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/cross.rs
+++ b/examples3d/cross.rs
@@ -3,10 +3,8 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use std::sync::Arc;
 use na::{Pnt3, Vec3, Translation};
-use ncollide::shape::{Plane, Cuboid, Compound};
-use ncollide::inspection::Repr3;
+use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics3d::volumetric::Volumetric;
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -31,17 +29,17 @@ fn main() {
      */
     let mut cross_geoms = Vec::new();
 
-    let edge_x = Box::new(Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21)));
-    let edge_y = Box::new(Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21)));
-    let edge_z = Box::new(Cuboid::new(Vec3::new(0.21f32, 0.21, 4.96)));
+    let edge_x = Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21));
+    let edge_y = Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21));
+    let edge_z = Cuboid::new(Vec3::new(0.21f32, 0.21, 4.96));
 
-    cross_geoms.push((na::one(), Arc::new(edge_x as Box<Repr3<f32>>)));
-    cross_geoms.push((na::one(), Arc::new(edge_y as Box<Repr3<f32>>)));
-    cross_geoms.push((na::one(), Arc::new(edge_z as Box<Repr3<f32>>)));
+    cross_geoms.push((na::one(), ShapeHandle::new(edge_x)));
+    cross_geoms.push((na::one(), ShapeHandle::new(edge_y)));
+    cross_geoms.push((na::one(), ShapeHandle::new(edge_z)));
 
     let compound = Compound::new(cross_geoms);
     let mass     = compound.mass_properties(1.0);
-    let cross    = Arc::new(Box::new(compound) as Box<Repr3<f32>>);
+    let cross    = ShapeHandle::new(compound);
 
     /*
      * Create the crosses

--- a/examples3d/cross.rs
+++ b/examples3d/cross.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid, Compound, ShapeHandle};
 use nphysics3d::volumetric::Volumetric;
 use nphysics3d::world::World;
@@ -15,12 +15,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -29,9 +29,9 @@ fn main() {
      */
     let mut cross_geoms = Vec::new();
 
-    let edge_x = Cuboid::new(Vec3::new(4.96f32, 0.21, 0.21));
-    let edge_y = Cuboid::new(Vec3::new(0.21f32, 4.96, 0.21));
-    let edge_z = Cuboid::new(Vec3::new(0.21f32, 0.21, 4.96));
+    let edge_x = Cuboid::new(Vector3::new(4.96f32, 0.21, 0.21));
+    let edge_y = Cuboid::new(Vector3::new(0.21f32, 4.96, 0.21));
+    let edge_z = Cuboid::new(Vector3::new(0.21f32, 0.21, 4.96));
 
     cross_geoms.push((na::one(), ShapeHandle::new(edge_x)));
     cross_geoms.push((na::one(), ShapeHandle::new(edge_y)));
@@ -60,7 +60,7 @@ fn main() {
 
                 let mut rb = RigidBody::new(cross.clone(), Some(mass), 0.3, 0.5);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -72,6 +72,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/fixed_bug_long_thin_box_one_shot_manifold.rs
+++ b/examples3d/fixed_bug_long_thin_box_one_shot_manifold.rs
@@ -43,7 +43,7 @@ fn main() {
      */
     let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * Create the boxes
@@ -58,7 +58,7 @@ fn main() {
 
     rb.append_translation(&Vec3::new(x, y, z));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Set up the testbed.

--- a/examples3d/fixed_bug_long_thin_box_one_shot_manifold.rs
+++ b/examples3d/fixed_bug_long_thin_box_one_shot_manifold.rs
@@ -25,7 +25,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -36,12 +36,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
@@ -53,10 +53,10 @@ fn main() {
     let y   = rad + 10.0;
     let z   = rad;
 
-    let geom   = Cuboid::new(Vec3::new(rad, rad * 10.0, rad));
+    let geom   = Cuboid::new(Vector3::new(rad, rad * 10.0, rad));
     let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-    rb.append_translation(&Vec3::new(x, y, z));
+    rb.append_translation(&Vector3::new(x, y, z));
 
     world.add_rigid_body(rb);
 
@@ -65,6 +65,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/fixed_bug_minkowski_sampling_fails_on_touching_objects.rs
+++ b/examples3d/fixed_bug_minkowski_sampling_fails_on_touching_objects.rs
@@ -24,7 +24,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -35,12 +35,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -53,16 +53,16 @@ fn main() {
     let y     = shift / 2.0;
     let z     = shift / 2.0;
 
-    let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(0.21, 4.96, 0.21)), 1.0, 0.3, 0.5);
-    rb.append_translation(&Vec3::new(x, y, z));
+    let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector3::new(0.21, 4.96, 0.21)), 1.0, 0.3, 0.5);
+    rb.append_translation(&Vector3::new(x, y, z));
     world.add_rigid_body(rb);
 
     /*
      * Create the ccd-enabled cube.
      */
-    let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(0.5, 0.5, 0.5)), 1.0, 0.3, 0.5);
-    rb.append_translation(&Vec3::new(x - 1.0, y + 2.0, z - 1.0));
-    rb.set_lin_vel(Vec3::new(10.0, 0.0, 10.0));
+    let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector3::new(0.5, 0.5, 0.5)), 1.0, 0.3, 0.5);
+    rb.append_translation(&Vector3::new(x - 1.0, y + 2.0, z - 1.0));
+    rb.set_lin_vel(Vector3::new(10.0, 0.0, 10.0));
     let body_handle = world.add_rigid_body(rb);
     world.add_ccd_to(&body_handle, 0.0, false);
 
@@ -71,6 +71,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/fixed_bug_minkowski_sampling_fails_on_touching_objects.rs
+++ b/examples3d/fixed_bug_minkowski_sampling_fails_on_touching_objects.rs
@@ -42,7 +42,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * First cuboid.
@@ -55,7 +55,7 @@ fn main() {
 
     let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(0.21, 4.96, 0.21)), 1.0, 0.3, 0.5);
     rb.append_translation(&Vec3::new(x, y, z));
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the ccd-enabled cube.
@@ -63,8 +63,8 @@ fn main() {
     let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(0.5, 0.5, 0.5)), 1.0, 0.3, 0.5);
     rb.append_translation(&Vec3::new(x - 1.0, y + 2.0, z - 1.0));
     rb.set_lin_vel(Vec3::new(10.0, 0.0, 10.0));
-    let body_handle = world.add_body(rb);
-    world.add_ccd_to(&body_handle, 0.0);
+    let body_handle = world.add_rigid_body(rb);
+    world.add_ccd_to(&body_handle, 0.0, false);
 
     /*
      * Set up the testbed.

--- a/examples3d/gravity.rs
+++ b/examples3d/gravity.rs
@@ -25,14 +25,14 @@ fn main() {
      */
     let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     let geom   = Plane::new(Vec3::new(0.0, -1.0, 0.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
     rb.append_translation(&Vec3::new(0.0, 50.0, 0.0));
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the balls
@@ -58,18 +58,18 @@ fn main() {
                 let color;
 
                 if j == 1 {
-                    // invert the gravity for the blue balls.
+                    // Invert the gravity for the blue balls.
                     rb.set_lin_acc_scale(Vec3::new(0.0, -1.0, 0.0));
                     color = Pnt3::new(0.0, 0.0, 1.0);
                 }
                 else {
-                    // double the gravity for the green balls.
+                    // Double the gravity for the green balls.
                     rb.set_lin_acc_scale(Vec3::new(0.0, 2.0, 0.0));
                     color = Pnt3::new(0.0, 1.0, 0.0);
                 }
 
-                let body = world.add_body(rb);
-                testbed.set_color(&body, color);
+                let rb_handle = world.add_rigid_body(rb);
+                testbed.set_rigid_body_color(&rb_handle, color);
             }
         }
     }

--- a/examples3d/gravity.rs
+++ b/examples3d/gravity.rs
@@ -5,7 +5,7 @@ extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
 use num::Float;
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Ball, Plane};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -18,19 +18,19 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
-    let geom   = Plane::new(Vec3::new(0.0, -1.0, 0.0));
+    let geom   = Plane::new(Vector3::new(0.0, -1.0, 0.0));
     let mut rb = RigidBody::new_static(geom, 0.3, 0.6);
 
-    rb.append_translation(&Vec3::new(0.0, 50.0, 0.0));
+    rb.append_translation(&Vector3::new(0.0, 50.0, 0.0));
 
     world.add_rigid_body(rb);
 
@@ -53,19 +53,19 @@ fn main() {
 
                 let mut rb = RigidBody::new_dynamic(Ball::new(rad), 1.0, 0.3, 0.6);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 let color;
 
                 if j == 1 {
                     // Invert the gravity for the blue balls.
-                    rb.set_lin_acc_scale(Vec3::new(0.0, -1.0, 0.0));
-                    color = Pnt3::new(0.0, 0.0, 1.0);
+                    rb.set_lin_acc_scale(Vector3::new(0.0, -1.0, 0.0));
+                    color = Point3::new(0.0, 0.0, 1.0);
                 }
                 else {
                     // Double the gravity for the green balls.
-                    rb.set_lin_acc_scale(Vec3::new(0.0, 2.0, 0.0));
-                    color = Pnt3::new(0.0, 1.0, 0.0);
+                    rb.set_lin_acc_scale(Vector3::new(0.0, 2.0, 0.0));
+                    color = Point3::new(0.0, 1.0, 0.0);
                 }
 
                 let rb_handle = world.add_rigid_body(rb);
@@ -78,6 +78,6 @@ fn main() {
      * Set up the testbed.
      */
     testbed.set_world(world);
-    testbed.look_at(Pnt3::new(-10.0, 50.0, -10.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-10.0, 50.0, -10.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/known_bug_excentric_convex.rs
+++ b/examples3d/known_bug_excentric_convex.rs
@@ -55,7 +55,7 @@ fn main() {
      */
     let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
     /*
      * Create the convex geometries.
@@ -86,7 +86,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/known_bug_excentric_convex.rs
+++ b/examples3d/known_bug_excentric_convex.rs
@@ -36,8 +36,8 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
-use ncollide::shape::{Plane, Convex};
+use na::{Point3, Vector3, Translation};
+use ncollide::shape::{Plane, ConvexHull};
 use ncollide::procedural;
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -48,12 +48,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
@@ -74,17 +74,17 @@ fn main() {
                 let y = j as f32 * shift + centery - excentricity;
                 let z = k as f32 * shift - centerz - excentricity;
 
-                let mut shape = procedural::cuboid(&Vec3::new(2.0 - 0.08, 2.0 - 0.08, 2.0 - 0.08));
+                let mut shape = procedural::cuboid(&Vector3::new(2.0 - 0.08, 2.0 - 0.08, 2.0 - 0.08));
 
                 for c in shape.coords.iter_mut() {
-                    *c = *c + Vec3::new(excentricity, excentricity, excentricity);
+                    *c = *c + Vector3::new(excentricity, excentricity, excentricity);
                 }
 
-                let geom = Convex::new(shape.coords);
+                let geom = ConvexHull::new(shape.coords);
                 let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
                 rb.set_deactivation_threshold(None);
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -96,6 +96,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/mesh.rs
+++ b/examples3d/mesh.rs
@@ -25,7 +25,7 @@ fn main() {
 
         let mesh: TriMesh3<f32> = TriMesh::new(Arc::new(vertices), Arc::new(indices), None, None);
 
-        world.add_body(RigidBody::new_static(mesh, 0.3, 0.6));
+        world.add_rigid_body(RigidBody::new_static(mesh, 0.3, 0.6));
     }
 
     /*

--- a/examples3d/mesh.rs
+++ b/examples3d/mesh.rs
@@ -4,7 +4,7 @@ extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
 use std::sync::Arc;
-use na::{Vec3, Pnt3};
+use na::{Vector3, Point3};
 use ncollide::shape::{TriMesh, TriMesh3};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -15,13 +15,13 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     let meshes = Testbed::load_obj("media/great_hall.obj");
 
     for (vertices, indices) in meshes.into_iter() {
         let vertices = vertices.iter().map(|v| *v * 3.0).collect();
-        let indices  = indices.chunks(3).map(|is| Pnt3::new(is[0], is[1], is[2])).collect();
+        let indices  = indices.chunks(3).map(|is| Point3::new(is[0], is[1], is[2])).collect();
 
         let mesh: TriMesh3<f32> = TriMesh::new(Arc::new(vertices), Arc::new(indices), None, None);
 

--- a/examples3d/nphysics_testbed3d/Cargo.toml
+++ b/examples3d/nphysics_testbed3d/Cargo.toml
@@ -7,7 +7,7 @@ authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 name = "nphysics_testbed3d"
 
 [dependencies]
-nalgebra = "0.6.*"
+nalgebra = "0.8.*"
 time = "0.1.*"
 rand = "0.3.*"
 glfw = "0.2.*"

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -2,12 +2,12 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use std::collections::HashMap;
 use rand::{SeedableRng, XorShiftRng, Rng};
-use na::{Pnt3, Iso3, Col, Translate};
+use na::{Point3, Isometry3, Column, Translate};
 use na;
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
 use kiss3d::camera::{Camera, ArcBall, FirstPerson};
-use ncollide::shape;
+use ncollide::shape::{Plane3, Ball3, Cuboid3, Cylinder3, Cone3, Compound3, TriMesh3, ConvexHull3};
 use ncollide::transformation;
 use ncollide::inspection::Repr3;
 use nphysics3d::object::{RigidBody, WorldObject, WorldObjectBorrowed, RigidBodyHandle, SensorHandle};
@@ -25,7 +25,7 @@ pub type GraphicsManagerHandle = Rc<RefCell<GraphicsManager>>;
 pub struct GraphicsManager {
     rand:             XorShiftRng,
     rb2sn:            HashMap<usize, Vec<Node>>,
-    rb2color:         HashMap<usize, Pnt3<f32>>,
+    rb2color:         HashMap<usize, Point3<f32>>,
     arc_ball:         ArcBall,
     first_person:     FirstPerson,
     curr_is_arc_ball: bool,
@@ -34,14 +34,14 @@ pub struct GraphicsManager {
 
 impl GraphicsManager {
     pub fn new() -> GraphicsManager {
-        let arc_ball     = ArcBall::new(Pnt3::new(10.0, 10.0, 10.0), Pnt3::new(0.0, 0.0, 0.0));
-        let first_person = FirstPerson::new(Pnt3::new(10.0, 10.0, 10.0), Pnt3::new(0.0, 0.0, 0.0));
+        let arc_ball     = ArcBall::new(Point3::new(10.0, 10.0, 10.0), Point3::new(0.0, 0.0, 0.0));
+        let first_person = FirstPerson::new(Point3::new(10.0, 10.0, 10.0), Point3::new(0.0, 0.0, 0.0));
 
         let mut rng: XorShiftRng = SeedableRng::from_seed([0, 2, 4, 8]);
 
         // the first colors are boring.
         for _ in 0usize .. 100 {
-            let _: Pnt3<f32> = rng.gen();
+            let _: Point3<f32> = rng.gen();
         }
 
         GraphicsManager {
@@ -85,7 +85,7 @@ impl GraphicsManager {
         self.rb2sn.remove(&key);
     }
 
-    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
         let key = WorldObject::rigid_body_uid(rb);
 
         self.rb2color.insert(key, color);
@@ -97,7 +97,7 @@ impl GraphicsManager {
         }
     }
 
-    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
         let key = WorldObject::sensor_uid(sensor);
 
         self.rb2color.insert(key, color);
@@ -110,7 +110,7 @@ impl GraphicsManager {
     }
 
     pub fn add(&mut self, window: &mut Window, object: WorldObject<f32>) {
-        let mut color = Pnt3::new(0.5, 0.5, 0.5);
+        let mut color = Point3::new(0.5, 0.5, 0.5);
 
         match self.rb2color.get(&object.uid()) {
             Some(c) => color = *c,
@@ -136,7 +136,7 @@ impl GraphicsManager {
         self.add_with_color(window, object, color)
     }
 
-    pub fn add_with_color(&mut self, window: &mut Window, object: WorldObject<f32>, color: Pnt3<f32>) {
+    pub fn add_with_color(&mut self, window: &mut Window, object: WorldObject<f32>, color: Point3<f32>) {
         let nodes = {
             let mut nodes = Vec::new();
 
@@ -160,45 +160,36 @@ impl GraphicsManager {
     fn add_repr(&mut self,
                 window: &mut Window,
                 object: WorldObject<f32>,
-                delta:  Iso3<f32>,
+                delta:  Isometry3<f32>,
                 shape:  &Repr3<f32>,
-                color:  Pnt3<f32>,
+                color:  Point3<f32>,
                 out:    &mut Vec<Node>) {
-        type Pl = shape::Plane3<f32>;
-        type Bl = shape::Ball3<f32>;
-        type Bo = shape::Cuboid3<f32>;
-        type Cy = shape::Cylinder3<f32>;
-        type Co = shape::Cone3<f32>;
-        type Cm = shape::Compound3<f32>;
-        type Tm = shape::TriMesh3<f32>;
-        type Cx = shape::Convex3<f32>;
-
         let repr = shape.repr();
 
-        if let Some(s) = repr.downcast_ref::<Pl>() {
+        if let Some(s) = repr.downcast_ref::<Plane3<f32>>() {
             self.add_plane(window, object, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Bl>() {
+        else if let Some(s) = repr.downcast_ref::<Ball3<f32>>() {
             self.add_ball(window, object, delta, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Bo>() {
+        else if let Some(s) = repr.downcast_ref::<Cuboid3<f32>>() {
             self.add_box(window, object, delta, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Cx>() {
+        else if let Some(s) = repr.downcast_ref::<ConvexHull3<f32>>() {
             self.add_convex(window, object, delta, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Cy>() {
+        else if let Some(s) = repr.downcast_ref::<Cylinder3<f32>>() {
             self.add_cylinder(window, object, delta, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Co>() {
+        else if let Some(s) = repr.downcast_ref::<Cone3<f32>>() {
             self.add_cone(window, object, delta, s, color, out)
         }
-        else if let Some(s) = repr.downcast_ref::<Cm>() {
+        else if let Some(s) = repr.downcast_ref::<Compound3<f32>>() {
             for &(t, ref s) in s.shapes().iter() {
                 self.add_repr(window, object.clone(), delta * t, s.as_ref(), color, out)
             }
         }
-        else if let Some(s) = repr.downcast_ref::<Tm>() {
+        else if let Some(s) = repr.downcast_ref::<TriMesh3<f32>>() {
             self.add_mesh(window, object, delta, s, color, out);
         }
         else {
@@ -210,10 +201,10 @@ impl GraphicsManager {
     fn add_plane(&mut self,
                  window: &mut Window,
                  object: WorldObject<f32>,
-                 shape:  &shape::Plane3<f32>,
-                 color:  Pnt3<f32>,
+                 shape:  &Plane3<f32>,
+                 color:  Point3<f32>,
                  out:    &mut Vec<Node>) {
-        let position = na::translation(&object.borrow().position()).translate(&na::orig());
+        let position = na::translation(&object.borrow().position()).translate(&na::origin());
         let normal   = na::rotate(&object.borrow().position(), shape.normal());
 
         out.push(Node::Plane(Plane::new(object, &position, &normal, color, window)))
@@ -222,14 +213,14 @@ impl GraphicsManager {
     fn add_mesh(&mut self,
                 window: &mut Window,
                 object: WorldObject<f32>,
-                delta:  Iso3<f32>,
-                shape:   &shape::TriMesh3<f32>,
-                color:  Pnt3<f32>,
+                delta:  Isometry3<f32>,
+                shape:   &TriMesh3<f32>,
+                color:  Point3<f32>,
                 out:    &mut Vec<Node>) {
         let vertices = &**shape.vertices();
         let indices = &**shape.indices();
 
-        let is = indices.iter().map(|p| Pnt3::new(p.x as u32, p.y as u32, p.z as u32)).collect();
+        let is = indices.iter().map(|p| Point3::new(p.x as u32, p.y as u32, p.z as u32)).collect();
 
         out.push(Node::Mesh(Mesh::new(object, delta, vertices.clone(), is, color, window)))
     }
@@ -237,9 +228,9 @@ impl GraphicsManager {
     fn add_ball(&mut self,
                 window: &mut Window,
                 object: WorldObject<f32>,
-                delta:  Iso3<f32>,
-                shape:   &shape::Ball3<f32>,
-                color:  Pnt3<f32>,
+                delta:  Isometry3<f32>,
+                shape:   &Ball3<f32>,
+                color:  Point3<f32>,
                 out:    &mut Vec<Node>) {
         let margin = object.borrow().margin();
         out.push(Node::Ball(Ball::new(object, delta, shape.radius() + margin, color, window)))
@@ -248,9 +239,9 @@ impl GraphicsManager {
     fn add_box(&mut self,
                window: &mut Window,
                object: WorldObject<f32>,
-               delta:  Iso3<f32>,
-               shape:  &shape::Cuboid3<f32>,
-               color:  Pnt3<f32>,
+               delta:  Isometry3<f32>,
+               shape:  &Cuboid3<f32>,
+               color:  Point3<f32>,
                out:    &mut Vec<Node>) {
         let rx = shape.half_extents().x + object.borrow().margin();
         let ry = shape.half_extents().y + object.borrow().margin();
@@ -262,9 +253,9 @@ impl GraphicsManager {
     fn add_convex(&mut self,
                   window: &mut Window,
                   object: WorldObject<f32>,
-                  delta:  Iso3<f32>,
-                  shape:   &shape::Convex3<f32>,
-                  color:  Pnt3<f32>,
+                  delta:  Isometry3<f32>,
+                  shape:  &ConvexHull3<f32>,
+                  color:  Point3<f32>,
                   out:    &mut Vec<Node>) {
         out.push(Node::Convex(Convex::new(object, delta, &transformation::convex_hull3(shape.points()), color, window)))
     }
@@ -272,9 +263,9 @@ impl GraphicsManager {
     fn add_cylinder(&mut self,
                     window: &mut Window,
                     object: WorldObject<f32>,
-                    delta:  Iso3<f32>,
-                    shape:   &shape::Cylinder3<f32>,
-                    color:  Pnt3<f32>,
+                    delta:  Isometry3<f32>,
+                    shape:   &Cylinder3<f32>,
+                    color:  Point3<f32>,
                     out:    &mut Vec<Node>) {
         let r = shape.radius();
         let h = shape.half_height() * 2.0;
@@ -285,9 +276,9 @@ impl GraphicsManager {
     fn add_cone(&mut self,
                 window: &mut Window,
                 object: WorldObject<f32>,
-                delta:  Iso3<f32>,
-                shape:   &shape::Cone3<f32>,
-                color:  Pnt3<f32>,
+                delta:  Isometry3<f32>,
+                shape:  &Cone3<f32>,
+                color:  Point3<f32>,
                 out:    &mut Vec<Node>) {
         let r = shape.radius();
         let h = shape.half_height() * 2.0;
@@ -312,13 +303,13 @@ impl GraphicsManager {
                     let t      = rb.position();
                     let center = rb.center_of_mass();
 
-                    let x = t.rotation.col(0) * 0.25f32;
-                    let y = t.rotation.col(1) * 0.25f32;
-                    let z = t.rotation.col(2) * 0.25f32;
+                    let x = t.rotation.column(0) * 0.25f32;
+                    let y = t.rotation.column(1) * 0.25f32;
+                    let z = t.rotation.column(2) * 0.25f32;
 
-                    window.draw_line(center, &(*center + x), &Pnt3::new(1.0, 0.0, 0.0));
-                    window.draw_line(center, &(*center + y), &Pnt3::new(0.0, 1.0, 0.0));
-                    window.draw_line(center, &(*center + z), &Pnt3::new(0.0, 0.0, 1.0));
+                    window.draw_line(center, &(*center + x), &Point3::new(1.0, 0.0, 0.0));
+                    window.draw_line(center, &(*center + y), &Point3::new(0.0, 1.0, 0.0));
+                    window.draw_line(center, &(*center + z), &Point3::new(0.0, 0.0, 1.0));
                 }
             }
         }
@@ -353,7 +344,7 @@ impl GraphicsManager {
         }
     }
 
-    pub fn look_at(&mut self, eye: Pnt3<f32>, at: Pnt3<f32>) {
+    pub fn look_at(&mut self, eye: Point3<f32>, at: Point3<f32>) {
         self.arc_ball.look_at(eye, at);
         self.first_person.look_at(eye, at);
     }

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -10,7 +10,7 @@ use kiss3d::camera::{Camera, ArcBall, FirstPerson};
 use ncollide::shape;
 use ncollide::transformation;
 use ncollide::inspection::Repr3;
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::{RigidBody, WorldObject, WorldObjectBorrowed, RigidBodyHandle, SensorHandle};
 use objects::ball::Ball;
 use objects::box_node::Box;
 use objects::cylinder::Cylinder;
@@ -18,79 +18,9 @@ use objects::cone::Cone;
 use objects::mesh::Mesh;
 use objects::plane::Plane;
 use objects::convex::Convex;
+use objects::node::Node;
 
-
-pub enum Node {
-    Ball(Ball),
-    Box(Box),
-    Cylinder(Cylinder),
-    Cone(Cone),
-    Mesh(Mesh),
-    Plane(Plane),
-    Convex(Convex)
-}
-
-impl Node {
-    pub fn select(&mut self) {
-        match *self {
-            Node::Plane(ref mut n)             => n.select(),
-            Node::Ball(ref mut n)              => n.select(),
-            Node::Box(ref mut n)               => n.select(),
-            Node::Cylinder(ref mut n)          => n.select(),
-            Node::Cone(ref mut n)              => n.select(),
-            Node::Mesh(ref mut n)              => n.select(),
-            Node::Convex(ref mut n)            => n.select()
-        }
-    }
-
-    pub fn unselect(&mut self) {
-        match *self {
-            Node::Plane(ref mut n)             => n.unselect(),
-            Node::Ball(ref mut n)              => n.unselect(),
-            Node::Box(ref mut n)               => n.unselect(),
-            Node::Cylinder(ref mut n)          => n.unselect(),
-            Node::Cone(ref mut n)              => n.unselect(),
-            Node::Mesh(ref mut n)              => n.unselect(),
-            Node::Convex(ref mut n)            => n.unselect()
-        }
-    }
-
-    pub fn update(&mut self) {
-        match *self {
-            Node::Plane(ref mut n)             => n.update(),
-            Node::Ball(ref mut n)              => n.update(),
-            Node::Box(ref mut n)               => n.update(),
-            Node::Cylinder(ref mut n)          => n.update(),
-            Node::Cone(ref mut n)              => n.update(),
-            Node::Mesh(ref mut n)              => n.update(),
-            Node::Convex(ref mut n)            => n.update()
-        }
-    }
-
-    pub fn object(&self) -> &SceneNode {
-        match *self {
-            Node::Plane(ref n)             => n.object(),
-            Node::Ball(ref n)              => n.object(),
-            Node::Box(ref n)               => n.object(),
-            Node::Cylinder(ref n)          => n.object(),
-            Node::Cone(ref n)              => n.object(),
-            Node::Mesh(ref n)              => n.object(),
-            Node::Convex(ref n)            => n.object()
-        }
-    }
-
-    pub fn body<'a>(&'a self) -> &'a Rc<RefCell<RigidBody<f32>>> {
-        match *self {
-            Node::Plane(ref n)             => n.body(),
-            Node::Ball(ref n)              => n.body(),
-            Node::Box(ref n)               => n.body(),
-            Node::Cylinder(ref n)          => n.body(),
-            Node::Cone(ref n)              => n.body(),
-            Node::Mesh(ref n)              => n.body(),
-            Node::Convex(ref n)            => n.body()
-        }
-    }
-}
+pub type GraphicsManagerHandle = Rc<RefCell<GraphicsManager>>;
 
 pub struct GraphicsManager {
     rand:             XorShiftRng,
@@ -128,7 +58,7 @@ impl GraphicsManager {
     pub fn clear(&mut self, window: &mut Window) {
         for sns in self.rb2sn.values() {
             for sn in sns.iter() {
-                window.remove(&mut sn.object().clone());
+                window.remove(&mut sn.scene_node().clone());
             }
         }
 
@@ -140,13 +70,13 @@ impl GraphicsManager {
         self.aabbs.clear();
     }
 
-    pub fn remove(&mut self, window: &mut Window, body: &Rc<RefCell<RigidBody<f32>>>) {
-        let key = &**body as *const RefCell<RigidBody<f32>> as usize;
+    pub fn remove(&mut self, window: &mut Window, object: &WorldObject<f32>) {
+        let key = object.uid();
 
         match self.rb2sn.get(&key) {
             Some(sns) => {
                 for sn in sns.iter() {
-                    window.remove(&mut sn.object().clone());
+                    window.remove(&mut sn.scene_node().clone());
                 }
             },
             None => { }
@@ -155,47 +85,81 @@ impl GraphicsManager {
         self.rb2sn.remove(&key);
     }
 
-    pub fn set_color(&mut self, body: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
-        self.rb2color.insert(&**body as *const RefCell<RigidBody<f32>> as usize, color);
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+        let key = WorldObject::rigid_body_uid(rb);
+
+        self.rb2color.insert(key, color);
+
+        if let Some(ns) = self.rb2sn.get_mut(&key) {
+            for n in ns.iter_mut() {
+                n.set_color(color)
+            }
+        }
     }
 
-    pub fn add(&mut self, window: &mut Window, body: Rc<RefCell<RigidBody<f32>>>) {
-        let color;
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+        let key = WorldObject::sensor_uid(sensor);
 
-        match self.rb2color.get(&(&*body as *const RefCell<RigidBody<f32>> as usize)) {
+        self.rb2color.insert(key, color);
+
+        if let Some(ns) = self.rb2sn.get_mut(&key) {
+            for n in ns.iter_mut() {
+                n.set_color(color)
+            }
+        }
+    }
+
+    pub fn add(&mut self, window: &mut Window, object: WorldObject<f32>) {
+        let mut color = Pnt3::new(0.5, 0.5, 0.5);
+
+        match self.rb2color.get(&object.uid()) {
             Some(c) => color = *c,
             None    => {
-                if body.borrow().can_move() {
-                    color = self.rand.gen();
-                }
-                else {
-                    color = Pnt3::new(0.5, 0.5, 0.5);
+                match object {
+                    WorldObject::RigidBody(ref rb) => {
+                        if rb.borrow().can_move() {
+                            color = self.rand.gen();
+                        }
+                    }
+                    WorldObject::Sensor(ref sensor) => {
+                        if let Some(parent) = sensor.borrow().parent() {
+                            let uid = &**parent as *const RefCell<RigidBody<f32>> as usize;
+                            if let Some(pcolor) = self.rb2color.get(&uid) {
+                                color = *pcolor;
+                            }
+                        }
+                    }
                 }
             }
         }
 
-        self.add_with_color(window, body, color)
+        self.add_with_color(window, object, color)
     }
 
-    pub fn add_with_color(&mut self,
-                          window: &mut Window,
-                          body:   Rc<RefCell<RigidBody<f32>>>,
-                          color:  Pnt3<f32>) {
+    pub fn add_with_color(&mut self, window: &mut Window, object: WorldObject<f32>, color: Pnt3<f32>) {
         let nodes = {
-            let rb        = body.borrow();
             let mut nodes = Vec::new();
 
-            self.add_repr(window, body.clone(), na::one(), rb.shape_ref(), color, &mut nodes);
+            self.add_repr(window, object.clone(), na::one(), object.borrow().shape_ref(), color, &mut nodes);
 
             nodes
         };
 
-        self.rb2sn.insert(&*body as *const RefCell<RigidBody<f32>> as usize, nodes);
+        self.rb2sn.insert(object.uid(), nodes);
+
+        match object {
+            WorldObject::RigidBody(ref rb) => {
+                self.set_rigid_body_color(&rb, color);
+            },
+            WorldObject::Sensor(ref sensor) => {
+                self.set_sensor_color(&sensor, color);
+            }
+        }
     }
 
     fn add_repr(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody<f32>>>,
+                object: WorldObject<f32>,
                 delta:  Iso3<f32>,
                 shape:  &Repr3<f32>,
                 color:  Pnt3<f32>,
@@ -212,30 +176,30 @@ impl GraphicsManager {
         let repr = shape.repr();
 
         if let Some(s) = repr.downcast_ref::<Pl>() {
-            self.add_plane(window, body, s, color, out)
+            self.add_plane(window, object, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Bl>() {
-            self.add_ball(window, body, delta, s, color, out)
+            self.add_ball(window, object, delta, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Bo>() {
-            self.add_box(window, body, delta, s, color, out)
+            self.add_box(window, object, delta, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Cx>() {
-            self.add_convex(window, body, delta, s, color, out)
+            self.add_convex(window, object, delta, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Cy>() {
-            self.add_cylinder(window, body, delta, s, color, out)
+            self.add_cylinder(window, object, delta, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Co>() {
-            self.add_cone(window, body, delta, s, color, out)
+            self.add_cone(window, object, delta, s, color, out)
         }
         else if let Some(s) = repr.downcast_ref::<Cm>() {
             for &(t, ref s) in s.shapes().iter() {
-                self.add_repr(window, body.clone(), delta * t, &***s, color, out)
+                self.add_repr(window, object.clone(), delta * t, &***s, color, out)
             }
         }
         else if let Some(s) = repr.downcast_ref::<Tm>() {
-            self.add_mesh(window, body, delta, s, color, out);
+            self.add_mesh(window, object, delta, s, color, out);
         }
         else {
             panic!("Not yet implemented.")
@@ -245,19 +209,19 @@ impl GraphicsManager {
 
     fn add_plane(&mut self,
                  window: &mut Window,
-                 body:   Rc<RefCell<RigidBody<f32>>>,
-                 shape:   &shape::Plane3<f32>,
+                 object: WorldObject<f32>,
+                 shape:  &shape::Plane3<f32>,
                  color:  Pnt3<f32>,
                  out:    &mut Vec<Node>) {
-        let position = na::translation(body.borrow().position()).translate(&na::orig());
-        let normal   = na::rotate(body.borrow().position(), shape.normal());
+        let position = na::translation(&object.borrow().position()).translate(&na::orig());
+        let normal   = na::rotate(&object.borrow().position(), shape.normal());
 
-        out.push(Node::Plane(Plane::new(body, &position, &normal, color, window)))
+        out.push(Node::Plane(Plane::new(object, &position, &normal, color, window)))
     }
 
     fn add_mesh(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody<f32>>>,
+                object: WorldObject<f32>,
                 delta:  Iso3<f32>,
                 shape:   &shape::TriMesh3<f32>,
                 color:  Pnt3<f32>,
@@ -267,47 +231,47 @@ impl GraphicsManager {
 
         let is = indices.iter().map(|p| Pnt3::new(p.x as u32, p.y as u32, p.z as u32)).collect();
 
-        out.push(Node::Mesh(Mesh::new(body, delta, vertices.clone(), is, color, window)))
+        out.push(Node::Mesh(Mesh::new(object, delta, vertices.clone(), is, color, window)))
     }
 
     fn add_ball(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody<f32>>>,
+                object: WorldObject<f32>,
                 delta:  Iso3<f32>,
                 shape:   &shape::Ball3<f32>,
                 color:  Pnt3<f32>,
                 out:    &mut Vec<Node>) {
-        let margin = body.borrow().margin();
-        out.push(Node::Ball(Ball::new(body, delta, shape.radius() + margin, color, window)))
+        let margin = object.borrow().margin();
+        out.push(Node::Ball(Ball::new(object, delta, shape.radius() + margin, color, window)))
     }
 
     fn add_box(&mut self,
                window: &mut Window,
-               body:   Rc<RefCell<RigidBody<f32>>>,
+               object: WorldObject<f32>,
                delta:  Iso3<f32>,
-               shape:   &shape::Cuboid3<f32>,
+               shape:  &shape::Cuboid3<f32>,
                color:  Pnt3<f32>,
                out:    &mut Vec<Node>) {
-        let rx = shape.half_extents().x + body.borrow().margin();
-        let ry = shape.half_extents().y + body.borrow().margin();
-        let rz = shape.half_extents().z + body.borrow().margin();
+        let rx = shape.half_extents().x + object.borrow().margin();
+        let ry = shape.half_extents().y + object.borrow().margin();
+        let rz = shape.half_extents().z + object.borrow().margin();
 
-        out.push(Node::Box(Box::new(body, delta, rx, ry, rz, color, window)))
+        out.push(Node::Box(Box::new(object, delta, rx, ry, rz, color, window)))
     }
 
     fn add_convex(&mut self,
                   window: &mut Window,
-                  body:   Rc<RefCell<RigidBody<f32>>>,
+                  object: WorldObject<f32>,
                   delta:  Iso3<f32>,
                   shape:   &shape::Convex3<f32>,
                   color:  Pnt3<f32>,
                   out:    &mut Vec<Node>) {
-        out.push(Node::Convex(Convex::new(body, delta, &transformation::convex_hull3(shape.points()), color, window)))
+        out.push(Node::Convex(Convex::new(object, delta, &transformation::convex_hull3(shape.points()), color, window)))
     }
 
     fn add_cylinder(&mut self,
                     window: &mut Window,
-                    body:   Rc<RefCell<RigidBody<f32>>>,
+                    object: WorldObject<f32>,
                     delta:  Iso3<f32>,
                     shape:   &shape::Cylinder3<f32>,
                     color:  Pnt3<f32>,
@@ -315,12 +279,12 @@ impl GraphicsManager {
         let r = shape.radius();
         let h = shape.half_height() * 2.0;
 
-        out.push(Node::Cylinder(Cylinder::new(body, delta, r, h, color, window)))
+        out.push(Node::Cylinder(Cylinder::new(object, delta, r, h, color, window)))
     }
 
     fn add_cone(&mut self,
                 window: &mut Window,
-                body:   Rc<RefCell<RigidBody<f32>>>,
+                object: WorldObject<f32>,
                 delta:  Iso3<f32>,
                 shape:   &shape::Cone3<f32>,
                 color:  Pnt3<f32>,
@@ -328,7 +292,7 @@ impl GraphicsManager {
         let r = shape.radius();
         let h = shape.half_height() * 2.0;
 
-        out.push(Node::Cone(Cone::new(body, delta, r, h, color, window)))
+        out.push(Node::Cone(Cone::new(object, delta, r, h, color, window)))
     }
 
     pub fn draw(&mut self) {
@@ -342,18 +306,20 @@ impl GraphicsManager {
     pub fn draw_positions(&mut self, window: &mut Window) {
         for (_, ns) in self.rb2sn.iter_mut() {
             for n in ns.iter_mut() {
-                let rb = n.body().borrow();
+                let object = n.object().borrow();
 
-                let t      = rb.position();
-                let center = rb.center_of_mass();
+                if let WorldObjectBorrowed::RigidBody(rb) = object {
+                    let t      = rb.position();
+                    let center = rb.center_of_mass();
 
-                let x = t.rotation.col(0) * 0.25f32;
-                let y = t.rotation.col(1) * 0.25f32;
-                let z = t.rotation.col(2) * 0.25f32;
+                    let x = t.rotation.col(0) * 0.25f32;
+                    let y = t.rotation.col(1) * 0.25f32;
+                    let z = t.rotation.col(2) * 0.25f32;
 
-                window.draw_line(center, &(*center + x), &Pnt3::new(1.0, 0.0, 0.0));
-                window.draw_line(center, &(*center + y), &Pnt3::new(0.0, 1.0, 0.0));
-                window.draw_line(center, &(*center + z), &Pnt3::new(0.0, 0.0, 1.0));
+                    window.draw_line(center, &(*center + x), &Pnt3::new(1.0, 0.0, 0.0));
+                    window.draw_line(center, &(*center + y), &Pnt3::new(0.0, 1.0, 0.0));
+                    window.draw_line(center, &(*center + z), &Pnt3::new(0.0, 0.0, 1.0));
+                }
             }
         }
     }
@@ -369,7 +335,16 @@ impl GraphicsManager {
         self.curr_is_arc_ball = !self.curr_is_arc_ball;
     }
 
-    pub fn camera<'a>(&'a mut self) -> &'a mut Camera {
+    pub fn camera<'a>(&'a self) -> &'a Camera {
+        if self.curr_is_arc_ball {
+            &self.arc_ball as &'a Camera
+        }
+        else {
+            &self.first_person as &'a Camera
+        }
+    }
+
+    pub fn camera_mut<'a>(&'a mut self) -> &'a mut Camera {
         if self.curr_is_arc_ball {
             &mut self.arc_ball as &'a mut Camera
         }
@@ -383,7 +358,19 @@ impl GraphicsManager {
         self.first_person.look_at(eye, at);
     }
 
-    pub fn body_to_scene_node(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>) -> Option<&mut Vec<Node>> {
-        self.rb2sn.get_mut(&(&**rb as *const RefCell<RigidBody<f32>> as usize))
+    pub fn rigid_body_nodes(&self, rb: &RigidBodyHandle<f32>) -> Option<&Vec<Node>> {
+        self.rb2sn.get(&WorldObject::rigid_body_uid(rb))
+    }
+
+    pub fn sensor_nodes(&self, sensor: &SensorHandle<f32>) -> Option<&Vec<Node>> {
+        self.rb2sn.get(&WorldObject::sensor_uid(sensor))
+    }
+
+    pub fn rigid_body_nodes_mut(&mut self, rb: &RigidBodyHandle<f32>) -> Option<&mut Vec<Node>> {
+        self.rb2sn.get_mut(&WorldObject::rigid_body_uid(rb))
+    }
+
+    pub fn sensor_nodes_mut(&mut self, sensor: &SensorHandle<f32>) -> Option<&mut Vec<Node>> {
+        self.rb2sn.get_mut(&WorldObject::sensor_uid(sensor))
     }
 }

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -140,7 +140,7 @@ impl GraphicsManager {
         let nodes = {
             let mut nodes = Vec::new();
 
-            self.add_repr(window, object.clone(), na::one(), object.borrow().shape_ref(), color, &mut nodes);
+            self.add_repr(window, object.clone(), na::one(), object.borrow().shape().as_ref(), color, &mut nodes);
 
             nodes
         };
@@ -195,7 +195,7 @@ impl GraphicsManager {
         }
         else if let Some(s) = repr.downcast_ref::<Cm>() {
             for &(t, ref s) in s.shapes().iter() {
-                self.add_repr(window, object.clone(), delta * t, &***s, color, out)
+                self.add_repr(window, object.clone(), delta * t, s.as_ref(), color, out)
             }
         }
         else if let Some(s) = repr.downcast_ref::<Tm>() {

--- a/examples3d/nphysics_testbed3d/src/lib.rs
+++ b/examples3d/nphysics_testbed3d/src/lib.rs
@@ -8,7 +8,8 @@ extern crate nphysics3d;
 
 
 pub use testbed::Testbed;
+pub use engine::{GraphicsManager, GraphicsManagerHandle};
 
 mod testbed;
 mod engine;
-mod objects;
+pub mod objects;

--- a/examples3d/nphysics_testbed3d/src/objects/ball.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/ball.rs
@@ -1,22 +1,22 @@
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Ball {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>
 }
 
 impl Ball {
     pub fn new(body:   WorldObject<f32>,
-               delta:  Iso3<f32>,
+               delta:  Isometry3<f32>,
                radius: f32,
-               color:  Pnt3<f32>,
+               color:  Point3<f32>,
                window: &mut Window) -> Ball {
         let t         = body.borrow().position().clone();
         let is_sensor = body.is_sensor();
@@ -42,14 +42,14 @@ impl Ball {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
         self.color = self.base_color;
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/ball.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/ball.rs
@@ -1,25 +1,25 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Iso3};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Ball {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>
+    body:       WorldObject<f32>
 }
 
 impl Ball {
-    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:   WorldObject<f32>,
                delta:  Iso3<f32>,
                radius: f32,
                color:  Pnt3<f32>,
                window: &mut Window) -> Ball {
-        let t = body.borrow().position().clone();
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Ball {
             color:      color,
@@ -28,6 +28,11 @@ impl Ball {
             gfx:        window.add_sphere(radius),
             body:       body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.set_color(color.x, color.y, color.z);
         res.gfx.set_local_transformation(t * res.delta);
@@ -44,23 +49,25 @@ impl Ball {
         self.color = self.base_color;
     }
 
-    pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            self.gfx.set_local_transformation(*rb.position() * self.delta);
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn update(&mut self) {
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/box_node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/box_node.rs
@@ -1,24 +1,24 @@
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Box {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>,
 }
 
 impl Box {
     pub fn new(body:   WorldObject<f32>,
-               delta:  Iso3<f32>,
+               delta:  Isometry3<f32>,
                rx:     f32,
                ry:     f32,
                rz:     f32,
-               color:  Pnt3<f32>,
+               color:  Point3<f32>,
                window: &mut window::Window) -> Box {
         let gx = rx * 2.0;
         let gy = ry * 2.0;
@@ -47,14 +47,14 @@ impl Box {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
         self.color = self.base_color;
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/box_node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/box_node.rs
@@ -1,30 +1,30 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Iso3};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Box {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>,
+    body:       WorldObject<f32>,
 }
 
 impl Box {
-    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:   WorldObject<f32>,
                delta:  Iso3<f32>,
                rx:     f32,
                ry:     f32,
                rz:     f32,
                color:  Pnt3<f32>,
-                       window: &mut window::Window) -> Box {
+               window: &mut window::Window) -> Box {
         let gx = rx * 2.0;
         let gy = ry * 2.0;
         let gz = rz * 2.0;
-        let t  = body.borrow().position().clone();
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Box {
             color:      color,
@@ -33,6 +33,11 @@ impl Box {
             gfx:        window.add_cube(gx, gy, gz),
             body:       body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.set_color(color.x, color.y, color.z);
         res.gfx.set_local_transformation(t * res.delta);
@@ -49,23 +54,25 @@ impl Box {
         self.color = self.base_color;
     }
 
-    pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            self.gfx.set_local_transformation(*rb.position() * self.delta);
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn update(&mut self) {
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cone.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cone.rs
@@ -1,23 +1,23 @@
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Cone {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>,
 }
 
 impl Cone {
     pub fn new(body:   WorldObject<f32>,
-               delta:  Iso3<f32>,
+               delta:  Isometry3<f32>,
                r:      f32,
                h:      f32,
-               color:  Pnt3<f32>,
+               color:  Point3<f32>,
                window: &mut window::Window) -> Cone {
         let t         = body.borrow().position().clone();
         let is_sensor = body.is_sensor();
@@ -43,7 +43,7 @@ impl Cone {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
@@ -54,7 +54,7 @@ impl Cone {
         node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/cone.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cone.rs
@@ -1,26 +1,26 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Iso3};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Cone {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>,
+    body:       WorldObject<f32>,
 }
 
 impl Cone {
-    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:   WorldObject<f32>,
                delta:  Iso3<f32>,
                r:      f32,
                h:      f32,
                color:  Pnt3<f32>,
                window: &mut window::Window) -> Cone {
-        let t = body.borrow().position().clone();
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Cone {
             color:      color,
@@ -29,6 +29,11 @@ impl Cone {
             gfx:        window.add_cone(r, h),
             body:       body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.set_color(color.x, color.y, color.z);
         res.gfx.set_local_transformation(t * res.delta);
@@ -46,22 +51,24 @@ impl Cone {
     }
 
     pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            self.gfx.set_local_transformation(*rb.position() * self.delta);
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/convex.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/convex.rs
@@ -1,24 +1,24 @@
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use na;
 use ncollide::procedural::TriMesh;
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Convex {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>
 }
 
 impl Convex {
     pub fn new(body:   WorldObject<f32>,
-               delta:  Iso3<f32>,
-               convex: &TriMesh<Pnt3<f32>>,
-               color:  Pnt3<f32>,
+               delta:  Isometry3<f32>,
+               convex: &TriMesh<Point3<f32>>,
+               color:  Point3<f32>,
                window: &mut Window)
                -> Convex {
         let t         = body.borrow().position().clone();
@@ -45,14 +45,14 @@ impl Convex {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
         self.color = self.base_color;
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/convex.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/convex.rs
@@ -1,27 +1,28 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Iso3};
 use na;
 use ncollide::procedural::TriMesh;
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Convex {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>
+    body:       WorldObject<f32>
 }
 
 impl Convex {
-    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
-               delta:    Iso3<f32>,
-               convex:   &TriMesh<Pnt3<f32>>,
-               color:    Pnt3<f32>,
-               window:   &mut Window) -> Convex {
-        let t = body.borrow().position().clone();
+    pub fn new(body:   WorldObject<f32>,
+               delta:  Iso3<f32>,
+               convex: &TriMesh<Pnt3<f32>>,
+               color:  Pnt3<f32>,
+               window: &mut Window)
+               -> Convex {
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Convex {
             color:      color,
@@ -30,6 +31,11 @@ impl Convex {
             gfx:        window.add_trimesh(convex.clone(), na::one()),
             body:       body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.set_color(color.x, color.y, color.z);
         res.gfx.set_local_transformation(t * res.delta);
@@ -46,26 +52,25 @@ impl Convex {
         self.color = self.base_color;
     }
 
-    pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            {
-                self.gfx.set_local_transformation(*rb.position() * self.delta);
-            }
-
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn update(&mut self) {
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
@@ -1,26 +1,26 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Iso3};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Cylinder {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>,
+    body:       WorldObject<f32>,
 }
 
 impl Cylinder {
-    pub fn new(body:   Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:   WorldObject<f32>,
                delta:  Iso3<f32>,
-               r:     f32,
-               h:     f32,
+               r:      f32,
+               h:      f32,
                color:  Pnt3<f32>,
                window: &mut window::Window) -> Cylinder {
-        let t = body.borrow().position().clone();
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Cylinder {
             color:      color,
@@ -29,6 +29,11 @@ impl Cylinder {
             gfx:   window.add_cylinder(r, h),
             body:  body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
         res.gfx.set_color(color.x, color.y, color.z);
         res.gfx.set_local_transformation(t * res.delta);
         res.update();
@@ -45,22 +50,24 @@ impl Cylinder {
     }
 
     pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            self.gfx.set_local_transformation(*rb.position() * self.delta);
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
@@ -1,23 +1,23 @@
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Cylinder {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>,
 }
 
 impl Cylinder {
     pub fn new(body:   WorldObject<f32>,
-               delta:  Iso3<f32>,
+               delta:  Isometry3<f32>,
                r:      f32,
                h:      f32,
-               color:  Pnt3<f32>,
+               color:  Point3<f32>,
                window: &mut window::Window) -> Cylinder {
         let t         = body.borrow().position().clone();
         let is_sensor = body.is_sensor();
@@ -42,7 +42,7 @@ impl Cylinder {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
@@ -53,7 +53,7 @@ impl Cylinder {
         node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/mesh.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/mesh.rs
@@ -3,25 +3,25 @@ use std::cell::RefCell;
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
 use kiss3d::resource;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use na;
 use nphysics3d::object::WorldObject;
 use objects::node;
 
 pub struct Mesh {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>
 }
 
 impl Mesh {
     pub fn new(body:     WorldObject<f32>,
-               delta:    Iso3<f32>,
-               vertices: Vec<Pnt3<f32>>,
-               indices:  Vec<Pnt3<u32>>,
-               color:    Pnt3<f32>,
+               delta:    Isometry3<f32>,
+               vertices: Vec<Point3<f32>>,
+               indices:  Vec<Point3<u32>>,
+               color:    Point3<f32>,
                window:   &mut Window) -> Mesh {
         let vs = vertices;
         let is = indices;
@@ -52,14 +52,14 @@ impl Mesh {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
         self.color = self.base_color;
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/mesh.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/mesh.rs
@@ -5,18 +5,19 @@ use kiss3d::scene::SceneNode;
 use kiss3d::resource;
 use na::{Pnt3, Iso3};
 use na;
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
+use objects::node;
 
 pub struct Mesh {
     color:      Pnt3<f32>,
     base_color: Pnt3<f32>,
     delta:      Iso3<f32>,
     gfx:        SceneNode,
-    body:       Rc<RefCell<RigidBody<f32>>>
+    body:       WorldObject<f32>
 }
 
 impl Mesh {
-    pub fn new(body:     Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:     WorldObject<f32>,
                delta:    Iso3<f32>,
                vertices: Vec<Pnt3<f32>>,
                indices:  Vec<Pnt3<u32>>,
@@ -26,7 +27,8 @@ impl Mesh {
         let is = indices;
 
         let mesh = resource::Mesh::new(vs, is, None, None, false);
-        let t    = body.borrow().position().clone();
+        let t         = body.borrow().position().clone();
+        let is_sensor = body.is_sensor();
 
         let mut res = Mesh {
             color:      color,
@@ -35,6 +37,11 @@ impl Mesh {
             gfx:        window.add_mesh(Rc::new(RefCell::new(mesh)), na::one()),
             body:       body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.enable_backface_culling(false);
         res.gfx.set_color(color.x, color.y, color.z);
@@ -52,26 +59,25 @@ impl Mesh {
         self.color = self.base_color;
     }
 
-    pub fn update(&mut self) {
-        let rb = self.body.borrow();
-
-        if rb.is_active() {
-            {
-                self.gfx.set_local_transformation(*rb.position() * self.delta);
-            }
-
-            self.gfx.set_color(self.color.x, self.color.y, self.color.z);
-        }
-        else {
-            self.gfx.set_color(self.color.x * 0.25, self.color.y * 0.25, self.color.z * 0.25);
-        }
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+        self.color = color;
+        self.base_color = color;
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn update(&mut self) {
+        node::update_scene_node(&mut self.gfx, &self.body, &self.color, &self.delta);
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/mod.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/mod.rs
@@ -5,4 +5,5 @@ pub mod cylinder;
 pub mod cone;
 pub mod mesh;
 pub mod convex;
+pub mod node;
 // pub mod parametric_surface;

--- a/examples3d/nphysics_testbed3d/src/objects/node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/node.rs
@@ -1,0 +1,133 @@
+use kiss3d::scene::SceneNode;
+use na::{Iso3, Pnt3};
+use nphysics3d::object::{WorldObject, WorldObjectBorrowed};
+use objects::ball::Ball;
+use objects::box_node::Box;
+use objects::cylinder::Cylinder;
+use objects::cone::Cone;
+use objects::mesh::Mesh;
+use objects::plane::Plane;
+use objects::convex::Convex;
+
+pub enum Node {
+    Ball(Ball),
+    Box(Box),
+    Cylinder(Cylinder),
+    Cone(Cone),
+    Mesh(Mesh),
+    Plane(Plane),
+    Convex(Convex)
+}
+
+impl Node {
+    pub fn select(&mut self) {
+        match *self {
+            Node::Plane(ref mut n)    => n.select(),
+            Node::Ball(ref mut n)     => n.select(),
+            Node::Box(ref mut n)      => n.select(),
+            Node::Cylinder(ref mut n) => n.select(),
+            Node::Cone(ref mut n)     => n.select(),
+            Node::Mesh(ref mut n)     => n.select(),
+            Node::Convex(ref mut n)   => n.select()
+        }
+    }
+
+    pub fn unselect(&mut self) {
+        match *self {
+            Node::Plane(ref mut n)    => n.unselect(),
+            Node::Ball(ref mut n)     => n.unselect(),
+            Node::Box(ref mut n)      => n.unselect(),
+            Node::Cylinder(ref mut n) => n.unselect(),
+            Node::Cone(ref mut n)     => n.unselect(),
+            Node::Mesh(ref mut n)     => n.unselect(),
+            Node::Convex(ref mut n)   => n.unselect()
+        }
+    }
+
+    pub fn update(&mut self) {
+        match *self {
+            Node::Plane(ref mut n)    => n.update(),
+            Node::Ball(ref mut n)     => n.update(),
+            Node::Box(ref mut n)      => n.update(),
+            Node::Cylinder(ref mut n) => n.update(),
+            Node::Cone(ref mut n)     => n.update(),
+            Node::Mesh(ref mut n)     => n.update(),
+            Node::Convex(ref mut n)   => n.update()
+        }
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
+        match *self {
+            Node::Plane(ref n)    => n.scene_node(),
+            Node::Ball(ref n)     => n.scene_node(),
+            Node::Box(ref n)      => n.scene_node(),
+            Node::Cylinder(ref n) => n.scene_node(),
+            Node::Cone(ref n)     => n.scene_node(),
+            Node::Mesh(ref n)     => n.scene_node(),
+            Node::Convex(ref n)   => n.scene_node()
+        }
+    }
+
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        match *self {
+            Node::Plane(ref mut n)    => n.scene_node_mut(),
+            Node::Ball(ref mut n)     => n.scene_node_mut(),
+            Node::Box(ref mut n)      => n.scene_node_mut(),
+            Node::Cylinder(ref mut n) => n.scene_node_mut(),
+            Node::Cone(ref mut n)     => n.scene_node_mut(),
+            Node::Mesh(ref mut n)     => n.scene_node_mut(),
+            Node::Convex(ref mut n)   => n.scene_node_mut()
+        }
+    }
+
+    pub fn object<'a>(&'a self) -> &'a WorldObject<f32> {
+        match *self {
+            Node::Plane(ref n)    => n.object(),
+            Node::Ball(ref n)     => n.object(),
+            Node::Box(ref n)      => n.object(),
+            Node::Cylinder(ref n) => n.object(),
+            Node::Cone(ref n)     => n.object(),
+            Node::Mesh(ref n)     => n.object(),
+            Node::Convex(ref n)   => n.object()
+        }
+    }
+
+    pub fn set_color(&mut self, color: Pnt3<f32>)  {
+        match *self {
+            Node::Plane(ref mut n)    => n.set_color(color),
+            Node::Ball(ref mut n)     => n.set_color(color),
+            Node::Box(ref mut n)      => n.set_color(color),
+            Node::Cylinder(ref mut n) => n.set_color(color),
+            Node::Cone(ref mut n)     => n.set_color(color),
+            Node::Mesh(ref mut n)     => n.set_color(color),
+            Node::Convex(ref mut n)   => n.set_color(color)
+        }
+    }
+}
+
+
+pub fn update_scene_node(node:   &mut SceneNode,
+                         object: &WorldObject<f32>,
+                         color:  &Pnt3<f32>,
+                         delta:  &Iso3<f32>) {
+    let rb = object.borrow();
+
+    match rb {
+        WorldObjectBorrowed::RigidBody(rb) => {
+            if rb.is_active() {
+                node.set_local_transformation(*rb.position() * *delta);
+                node.set_color(color.x, color.y, color.z);
+            }
+            else {
+                node.set_color(color.x * 0.25, color.y * 0.25, color.z * 0.25);
+            }
+        },
+        WorldObjectBorrowed::Sensor(s) => {
+            if let Some(rb) = s.parent() {
+                if rb.borrow().is_active() {
+                    node.set_local_transformation(s.position() * *delta);
+                }
+            }
+        }
+    }
+}

--- a/examples3d/nphysics_testbed3d/src/objects/node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/node.rs
@@ -1,5 +1,5 @@
 use kiss3d::scene::SceneNode;
-use na::{Iso3, Pnt3};
+use na::{Isometry3, Point3};
 use nphysics3d::object::{WorldObject, WorldObjectBorrowed};
 use objects::ball::Ball;
 use objects::box_node::Box;
@@ -92,7 +92,7 @@ impl Node {
         }
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>)  {
+    pub fn set_color(&mut self, color: Point3<f32>)  {
         match *self {
             Node::Plane(ref mut n)    => n.set_color(color),
             Node::Ball(ref mut n)     => n.set_color(color),
@@ -108,8 +108,8 @@ impl Node {
 
 pub fn update_scene_node(node:   &mut SceneNode,
                          object: &WorldObject<f32>,
-                         color:  &Pnt3<f32>,
-                         delta:  &Iso3<f32>) {
+                         color:  &Point3<f32>,
+                         delta:  &Isometry3<f32>) {
     let rb = object.borrow();
 
     match rb {

--- a/examples3d/nphysics_testbed3d/src/objects/parametric_surface.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/parametric_surface.rs
@@ -2,25 +2,25 @@ use std::rc::Rc;
 use std::cell::RefCell;
 use kiss3d::window::Window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Iso3};
+use na::{Point3, Isometry3};
 use na;
 use nphysics::object::WorldObject;
 use ncollide::procedural;
 use ncollide::parametric;
 
 pub struct ParametricSurface {
-    color:      Pnt3<f32>,
-    base_color: Pnt3<f32>,
-    delta:      Iso3<f32>,
+    color:      Point3<f32>,
+    base_color: Point3<f32>,
+    delta:      Isometry3<f32>,
     gfx:        SceneNode,
     body:       WorldObject<f32>
 }
 
 impl ParametricSurface {
     pub fn new<S: parametric::ParametricSurface>(body:    WorldObject<f32>,
-                                                 delta:   Iso3<f32>,
+                                                 delta:   Isometry3<f32>,
                                                  surface: &S,
-                                                 color:   Pnt3<f32>,
+                                                 color:   Point3<f32>,
                                                  window:  &mut Window)
                                                  -> ParametricSurface {
         let t     = na::transformation(body.borrow().deref());
@@ -48,14 +48,14 @@ impl ParametricSurface {
     }
 
     pub fn select(&mut self) {
-        self.color = Pnt3::new(1.0, 0.0, 0.0);
+        self.color = Point3::new(1.0, 0.0, 0.0);
     }
 
     pub fn unselect(&mut self) {
         self.color = self.base_color;
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         res.gfx.set_color(color.x, color.y, color.z);
         self.color = color;
         self.base_color = color;

--- a/examples3d/nphysics_testbed3d/src/objects/plane.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/plane.rs
@@ -1,26 +1,31 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use na;
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
 use na::{Pnt3, Vec3};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::WorldObject;
 
 pub struct Plane {
     gfx:  SceneNode,
-    body: Rc<RefCell<RigidBody<f32>>>
+    body: WorldObject<f32>
 }
 
 impl Plane {
-    pub fn new(body:         Rc<RefCell<RigidBody<f32>>>,
+    pub fn new(body:         WorldObject<f32>,
                world_pos:    &Pnt3<f32>,
                world_normal: &Vec3<f32>,
                color:        Pnt3<f32>,
                window:       &mut window::Window) -> Plane {
+        let is_sensor = body.is_sensor();
+
         let mut res = Plane {
             gfx:  window.add_quad(100.0, 100.0, 10, 10),
             body: body
         };
+
+        if is_sensor {
+            res.gfx.set_surface_rendering_activation(false);
+            res.gfx.set_lines_width(1.0);
+        }
 
         res.gfx.set_color(color.x, color.y, color.z);
 
@@ -50,11 +55,19 @@ impl Plane {
         // FIXME: atm we assume the plane does not move
     }
 
-    pub fn object(&self) -> &SceneNode {
+    pub fn set_color(&mut self, color: Pnt3<f32>) {
+        self.gfx.set_color(color.x, color.y, color.z);
+    }
+
+    pub fn scene_node(&self) -> &SceneNode {
         &self.gfx
     }
 
-    pub fn body(&self) -> &Rc<RefCell<RigidBody<f32>>> {
+    pub fn scene_node_mut(&mut self) -> &mut SceneNode {
+        &mut self.gfx
+    }
+
+    pub fn object(&self) -> &WorldObject<f32> {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/plane.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/plane.rs
@@ -1,7 +1,7 @@
 use na;
 use kiss3d::window;
 use kiss3d::scene::SceneNode;
-use na::{Pnt3, Vec3};
+use na::{Point3, Vector3};
 use nphysics3d::object::WorldObject;
 
 pub struct Plane {
@@ -11,9 +11,9 @@ pub struct Plane {
 
 impl Plane {
     pub fn new(body:         WorldObject<f32>,
-               world_pos:    &Pnt3<f32>,
-               world_normal: &Vec3<f32>,
-               color:        Pnt3<f32>,
+               world_pos:    &Point3<f32>,
+               world_normal: &Vector3<f32>,
+               color:        Point3<f32>,
                window:       &mut window::Window) -> Plane {
         let is_sensor = body.is_sensor();
 
@@ -32,10 +32,10 @@ impl Plane {
         let up;
 
         if na::is_zero(&world_normal.z) && na::is_zero(&world_normal.y) {
-            up = Vec3::z();
+            up = Vector3::z();
         }
         else {
-            up = Vec3::x();
+            up = Vector3::x();
         }
 
         res.gfx.reorient(world_pos, &(*world_pos + *world_normal), &up);
@@ -55,7 +55,7 @@ impl Plane {
         // FIXME: atm we assume the plane does not move
     }
 
-    pub fn set_color(&mut self, color: Pnt3<f32>) {
+    pub fn set_color(&mut self, color: Point3<f32>) {
         self.gfx.set_color(color.x, color.y, color.z);
     }
 

--- a/examples3d/nphysics_testbed3d/src/testbed.rs
+++ b/examples3d/nphysics_testbed3d/src/testbed.rs
@@ -15,12 +15,11 @@ use ncollide::shape::{Cuboid, Ball};
 use ncollide::ray;
 use ncollide::ray::Ray;
 use ncollide::world::CollisionGroups;
-use nphysics3d::detection::Detector;
 use nphysics3d::detection::constraint::Constraint;
 use nphysics3d::detection::joint::{Anchor, Fixed, Joint};
-use nphysics3d::object::RigidBody;
+use nphysics3d::object::{RigidBody, RigidBodyHandle, SensorHandle, WorldObject};
 use nphysics3d::world::World;
-use engine::GraphicsManager;
+use engine::{GraphicsManager, GraphicsManagerHandle};
 
 
 fn usage(exe_name: &str) {
@@ -48,7 +47,7 @@ fn usage(exe_name: &str) {
 pub struct Testbed {
     world:    World<f32>,
     window:   Window,
-    graphics: GraphicsManager,
+    graphics: GraphicsManagerHandle,
 }
 
 impl Testbed {
@@ -59,7 +58,7 @@ impl Testbed {
         Testbed {
             world:    World::new(),
             window:   window,
-            graphics: graphics
+            graphics: Rc::new(RefCell::new(graphics))
         }
     }
 
@@ -74,19 +73,35 @@ impl Testbed {
     pub fn set_world(&mut self, world: World<f32>) {
         self.world = world;
 
-        self.graphics.clear(&mut self.window);
+        self.graphics.borrow_mut().clear(&mut self.window);
 
-        for rb in self.world.bodies() {
-            self.graphics.add(&mut self.window, rb.clone());
+        for rb in self.world.rigid_bodies() {
+            self.graphics.borrow_mut().add(&mut self.window, WorldObject::RigidBody(rb.clone()));
+        }
+
+        for sensor in self.world.sensors() {
+            self.graphics.borrow_mut().add(&mut self.window, WorldObject::Sensor(sensor.clone()));
         }
     }
 
     pub fn look_at(&mut self, eye: Pnt3<f32>, at: Pnt3<f32>) {
-        self.graphics.look_at(eye, at);
+        self.graphics.borrow_mut().look_at(eye, at);
     }
 
-    pub fn set_color(&mut self, rb: &Rc<RefCell<RigidBody<f32>>>, color: Pnt3<f32>) {
-        self.graphics.set_color(rb, color);
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+        self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+    }
+
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+        self.graphics.borrow_mut().set_sensor_color(sensor, color);
+    }
+
+    pub fn world(&self) -> &World<f32> {
+        &self.world
+    }
+
+    pub fn graphics(&self) -> GraphicsManagerHandle {
+        self.graphics.clone()
     }
 
     pub fn load_obj(path: &str) -> Vec<(Vec<Pnt3<f32>>, Vec<usize>)> {
@@ -138,7 +153,7 @@ impl Testbed {
         let mut draw_colls = false;
 
         let mut cursor_pos = Pnt2::new(0.0f32, 0.0);
-        let mut grabbed_object: Option<Rc<RefCell<RigidBody<f32>>>> = None;
+        let mut grabbed_object: Option<RigidBodyHandle<f32>> = None;
         let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
         let mut grabbed_object_plane: (Pnt3<f32>, Vec3<f32>) = (na::orig(), na::zero());
 
@@ -146,29 +161,29 @@ impl Testbed {
         self.window.set_framerate_limit(Some(60));
         self.window.set_light(Light::StickToCamera);
 
-
         while !self.window.should_close() {
             for mut event in self.window.events().iter() {
                 match event.value {
                     WindowEvent::MouseButton(MouseButton::Button2, Action::Press, glfw::Control) => {
+                        let mut graphics = self.graphics.borrow_mut();
                         let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5f32, 0.5f32));
                         let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
                         let size = self.window.size();
-                        let (pos, dir) = self.graphics.camera().unproject(&cursor_pos, &size);
+                        let (pos, dir) = graphics.camera().unproject(&cursor_pos, &size);
 
                         rb.set_translation(pos.to_vec());
                         rb.set_lin_vel(dir * 1000.0f32);
 
-                        let body = self.world.add_body(rb);
-                        self.world.add_ccd_to(&body, 1.0);
-                        self.graphics.add(&mut self.window, body);
+                        let body = self.world.add_rigid_body(rb);
+                        self.world.add_ccd_to(&body, 1.0, false);
+                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
                     },
                     WindowEvent::MouseButton(MouseButton::Button1, Action::Press, modifier) => {
                         if modifier.contains(glfw::Shift) {
                             // XXX: huge and uggly code duplication
                             let size = self.window.size();
-                            let (pos, dir) = self.graphics.camera().unproject(&cursor_pos, &size);
+                            let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
                             let ray = Ray::new(pos, dir);
 
                             // cast the ray
@@ -176,20 +191,24 @@ impl Testbed {
                             let mut minb   = None;
 
                             let all_groups = &CollisionGroups::new();
+                            // FIXME: add the Sensor group to the blacklist so that they are not
+                            // reported for ray-casting.
                             for (b, inter) in self.world
                                                   .collision_world()
                                                   .interferences_with_ray(&ray, all_groups) {
-                                if inter.toi < mintoi {
-                                    mintoi = inter.toi;
-                                    minb   = Some(b.data.clone());
+                                if  inter.toi < mintoi {
+                                    if let &WorldObject::RigidBody(ref rb) = &b.data {
+                                        mintoi = inter.toi;
+                                        minb   = Some(rb.clone());
+                                    }
                                 }
                             }
 
                             if minb.is_some() {
                                 let b = minb.as_ref().unwrap();
                                 if b.borrow().can_move() {
-                                    self.world.remove_body(b);
-                                    self.graphics.remove(&mut self.window, b);
+                                    self.world.remove_rigid_body(b);
+                                    self.graphics.borrow_mut().remove(&mut self.window, &WorldObject::RigidBody(b.clone()));
                                 }
                             }
 
@@ -198,8 +217,8 @@ impl Testbed {
                         else if modifier.contains(glfw::Control) {
                             match grabbed_object {
                                 Some(ref rb) => {
-                                    for sn in self.graphics.body_to_scene_node(rb).unwrap().iter_mut() {
-                                        sn.unselect()
+                                    for n in self.graphics.borrow_mut().rigid_body_nodes_mut(rb).unwrap().iter_mut() {
+                                        n.unselect()
                                     }
                                 },
                                 None => { }
@@ -207,7 +226,7 @@ impl Testbed {
 
                             // XXX: huge and uggly code duplication
                             let size = self.window.size();
-                            let (pos, dir) = self.graphics.camera().unproject(&cursor_pos, &size);
+                            let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
                             let ray = Ray::new(pos, dir);
 
                             // cast the ray
@@ -218,9 +237,11 @@ impl Testbed {
                             for (b, inter) in self.world
                                                   .collision_world()
                                                   .interferences_with_ray(&ray, &all_groups) {
-                                if inter.toi < mintoi {
-                                    mintoi = inter.toi;
-                                    minb   = Some(b.data.clone());
+                                if  inter.toi < mintoi {
+                                    if let &WorldObject::RigidBody(ref rb) = &b.data {
+                                        mintoi = inter.toi;
+                                        minb   = Some(rb.clone());
+                                    }
                                 }
                             }
 
@@ -233,7 +254,7 @@ impl Testbed {
 
                             match grabbed_object {
                                 Some(ref b) => {
-                                    for sn in self.graphics.body_to_scene_node(b).unwrap().iter_mut() {
+                                    for n in self.graphics.borrow_mut().rigid_body_nodes_mut(b).unwrap().iter_mut() {
                                         match grabbed_object_joint {
                                             Some(ref j) => self.world.remove_fixed(j),
                                             None        => { }
@@ -248,7 +269,7 @@ impl Testbed {
                                         grabbed_object_plane = (attach2.translate(&na::orig()), -ray.dir);
                                         grabbed_object_joint = Some(self.world.add_fixed(joint));
                                         // add a joint
-                                        sn.select()
+                                        n.select()
                                     }
                                 },
                                 None => { }
@@ -258,10 +279,11 @@ impl Testbed {
                         }
                     },
                     WindowEvent::MouseButton(_, Action::Release, _) => {
+                        let mut graphics = self.graphics.borrow_mut();
                         match grabbed_object {
                             Some(ref b) => {
-                                for sn in self.graphics.body_to_scene_node(b).unwrap().iter_mut() {
-                                    sn.unselect()
+                                for n in graphics.rigid_body_nodes_mut(b).unwrap().iter_mut() {
+                                    n.unselect()
                                 }
                             },
                             None => { }
@@ -283,7 +305,7 @@ impl Testbed {
                         match grabbed_object_joint {
                             Some(ref j) => {
                                 let size = self.window.size();
-                                let (pos, dir) = self.graphics.camera().unproject(&cursor_pos, &size);
+                                let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
                                 let (ref ppos, ref pdir) = grabbed_object_plane;
 
                                 match ray::plane_toi_with_ray(ppos, pdir, &Ray::new(pos, dir)) {
@@ -304,7 +326,7 @@ impl Testbed {
                             self.window.glfw_window().get_key(Key::RightControl) != Action::Release ||
                             self.window.glfw_window().get_key(Key::LeftControl)  != Action::Release;
                     },
-                    WindowEvent::Key(Key::Tab, _, Action::Release, _) => self.graphics.switch_cameras(),
+                    WindowEvent::Key(Key::Tab, _, Action::Release, _) => self.graphics.borrow_mut().switch_cameras(),
                     WindowEvent::Key(Key::T, _,   Action::Release, _) => {
                         if running == RunMode::Stop {
                             running = RunMode::Running;
@@ -325,24 +347,33 @@ impl Testbed {
                         // }
                     },
                     WindowEvent::Key(Key::Space, _, Action::Release, _) => {
+                        let mut graphics = self.graphics.borrow_mut();
                         draw_colls = !draw_colls;
-                        if draw_colls {
-                            self.window.scene_mut().set_lines_width(1.0);
-                            self.window.scene_mut().set_surface_rendering_activation(false);
-                        }
-                        else {
-                            self.window.scene_mut().set_lines_width(0.0);
-                            self.window.scene_mut().set_surface_rendering_activation(true);
+                        for rb in self.world.rigid_bodies() {
+                            // FIXME: ugly clone.
+                            if let Some(ns) = graphics.rigid_body_nodes_mut(rb) {
+                                for n in ns.iter_mut() {
+                                    if draw_colls {
+                                        n.scene_node_mut().set_lines_width(1.0);
+                                        n.scene_node_mut().set_surface_rendering_activation(false);
+                                    }
+                                    else {
+                                        n.scene_node_mut().set_lines_width(0.0);
+                                        n.scene_node_mut().set_surface_rendering_activation(true);
+                                    }
+                                }
+                            }
                         }
                     },
                     WindowEvent::Key(Key::Num1, _, Action::Press, _) => {
+                        let mut graphics = self.graphics.borrow_mut();
                         let geom   = Ball::new(0.5f32);
                         let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
                         let cam_transfom;
 
                         {
-                            let cam      = self.graphics.camera();
+                            let cam      = graphics.camera();
                             cam_transfom = na::inv(&cam.view_transform()).unwrap();
                         }
 
@@ -352,17 +383,18 @@ impl Testbed {
 
                         rb.set_lin_vel(front * 40.0f32);
 
-                        let body = self.world.add_body(rb);
-                        self.graphics.add(&mut self.window, body.clone());
+                        let body = self.world.add_rigid_body(rb);
+                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
                     },
                     WindowEvent::Key(Key::Num2, _, Action::Press, _) => {
+                        let mut graphics = self.graphics.borrow_mut();
                         let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5, 0.5));
                         let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
                         let cam_transform;
 
                         {
-                            let cam = self.graphics.camera();
+                            let cam = graphics.camera();
                             cam_transform = na::inv(&cam.view_transform()).unwrap();
                         }
 
@@ -372,8 +404,8 @@ impl Testbed {
 
                         rb.set_lin_vel(front * 40.0f32);
 
-                        let body = self.world.add_body(rb);
-                        self.graphics.add(&mut self.window, body.clone());
+                        let body = self.world.add_rigid_body(rb);
+                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
                     }
                     _ => { }
                 }
@@ -386,7 +418,7 @@ impl Testbed {
                 self.world.step(0.016);
                 dt = time::precise_time_s() - before;
 
-                self.graphics.draw();
+                self.graphics.borrow_mut().draw();
             }
             else {
                 dt = 0.0;
@@ -397,20 +429,20 @@ impl Testbed {
             }
 
             if draw_colls {
-                self.graphics.draw_positions(&mut self.window);
+                self.graphics.borrow_mut().draw_positions(&mut self.window);
                 draw_collisions(&mut self.window, &mut self.world);
             }
 
             let color = Pnt3::new(1.0, 1.0, 1.0);
 
             if running != RunMode::Stop {
-                self.window.draw_text(&dt.to_string()[..], &na::orig(), &font, &color);
+                self.window.draw_text(&format!("Time: {:.*}sec.", 4, dt)[..], &na::orig(), &font, &color);
             }
             else {
                 self.window.draw_text("Paused", &na::orig(), &font, &color);
             }
 
-            self.window.render_with_camera(self.graphics.camera());
+            self.window.render_with_camera(self.graphics.borrow_mut().camera_mut());
         }
     }
 }
@@ -425,7 +457,7 @@ enum RunMode {
 fn draw_collisions(window: &mut Window, physics: &mut World<f32>) {
     let mut collisions = Vec::new();
 
-    physics.interferences(&mut collisions);
+    physics.constraints(&mut collisions);
 
     for c in collisions.iter() {
         match *c {

--- a/examples3d/nphysics_testbed3d/src/testbed.rs
+++ b/examples3d/nphysics_testbed3d/src/testbed.rs
@@ -5,7 +5,7 @@ use std::path::Path;
 use time;
 use glfw;
 use glfw::{MouseButton, Key, Action, WindowEvent};
-use na::{Pnt2, Pnt3, Vec3, Translation, Translate, Iso3, Bounded};
+use na::{Point2, Point3, Vector3, Translation, Translate, Isometry3, Bounded};
 use na;
 use kiss3d::window::Window;
 use kiss3d::light::Light;
@@ -84,15 +84,15 @@ impl Testbed {
         }
     }
 
-    pub fn look_at(&mut self, eye: Pnt3<f32>, at: Pnt3<f32>) {
+    pub fn look_at(&mut self, eye: Point3<f32>, at: Point3<f32>) {
         self.graphics.borrow_mut().look_at(eye, at);
     }
 
-    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
         self.graphics.borrow_mut().set_rigid_body_color(rb, color);
     }
 
-    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Pnt3<f32>) {
+    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
         self.graphics.borrow_mut().set_sensor_color(sensor, color);
     }
 
@@ -104,7 +104,7 @@ impl Testbed {
         self.graphics.clone()
     }
 
-    pub fn load_obj(path: &str) -> Vec<(Vec<Pnt3<f32>>, Vec<usize>)> {
+    pub fn load_obj(path: &str) -> Vec<(Vec<Point3<f32>>, Vec<usize>)> {
         let path    = Path::new(path);
         let empty   = Path::new("_some_non_existant_folder"); // dont bother loading mtl files correctly
         let objects = obj::parse_file(&path, &empty, "").ok().expect("Unable to open the obj file.");
@@ -152,10 +152,10 @@ impl Testbed {
         let font           = Font::from_memory(font_mem, 60);
         let mut draw_colls = false;
 
-        let mut cursor_pos = Pnt2::new(0.0f32, 0.0);
+        let mut cursor_pos = Point2::new(0.0f32, 0.0);
         let mut grabbed_object: Option<RigidBodyHandle<f32>> = None;
         let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
-        let mut grabbed_object_plane: (Pnt3<f32>, Vec3<f32>) = (na::orig(), na::zero());
+        let mut grabbed_object_plane: (Point3<f32>, Vector3<f32>) = (na::origin(), na::zero());
 
 
         self.window.set_framerate_limit(Some(60));
@@ -166,13 +166,13 @@ impl Testbed {
                 match event.value {
                     WindowEvent::MouseButton(MouseButton::Button2, Action::Press, glfw::Control) => {
                         let mut graphics = self.graphics.borrow_mut();
-                        let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5f32, 0.5f32));
+                        let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5f32, 0.5f32));
                         let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
                         let size = self.window.size();
                         let (pos, dir) = graphics.camera().unproject(&cursor_pos, &size);
 
-                        rb.set_translation(pos.to_vec());
+                        rb.set_translation(pos.to_vector());
                         rb.set_lin_vel(dir * 1000.0f32);
 
                         let body = self.world.add_rigid_body(rb);
@@ -260,13 +260,13 @@ impl Testbed {
                                             None        => { }
                                         }
 
-                                        let _1: Iso3<f32> = na::one();
-                                        let attach2 = na::append_translation(&_1, (ray.orig + ray.dir * mintoi).as_vec());
-                                        let attach1 = na::inv(&na::transformation(b.borrow().position())).unwrap() * attach2;
+                                        let _1: Isometry3<f32> = na::one();
+                                        let attach2 = na::append_translation(&_1, (ray.origin + ray.dir * mintoi).as_vector());
+                                        let attach1 = na::inverse(&na::transformation(b.borrow().position())).unwrap() * attach2;
                                         let anchor1 = Anchor::new(Some(minb.as_ref().unwrap().clone()), attach1);
                                         let anchor2 = Anchor::new(None, attach2);
                                         let joint   = Fixed::new(anchor1, anchor2);
-                                        grabbed_object_plane = (attach2.translate(&na::orig()), -ray.dir);
+                                        grabbed_object_plane = (attach2.translate(&na::origin()), -ray.dir);
                                         grabbed_object_joint = Some(self.world.add_fixed(joint));
                                         // add a joint
                                         n.select()
@@ -310,8 +310,8 @@ impl Testbed {
 
                                 match ray::plane_toi_with_ray(ppos, pdir, &Ray::new(pos, dir)) {
                                     Some(inter) => {
-                                        let _1: Iso3<f32> = na::one();
-                                        j.borrow_mut().set_local2(na::append_translation(&_1, (pos + dir * inter).as_vec()))
+                                        let _1: Isometry3<f32> = na::one();
+                                        j.borrow_mut().set_local2(na::append_translation(&_1, (pos + dir * inter).as_vector()))
                                     },
                                     None => { }
                                 }
@@ -374,12 +374,12 @@ impl Testbed {
 
                         {
                             let cam      = graphics.camera();
-                            cam_transfom = na::inv(&cam.view_transform()).unwrap();
+                            cam_transfom = na::inverse(&cam.view_transform()).unwrap();
                         }
 
                         rb.append_translation(&na::translation(&cam_transfom));
 
-                        let front = -na::rotate(&cam_transfom, &Vec3::z());
+                        let front = -na::rotate(&cam_transfom, &Vector3::z());
 
                         rb.set_lin_vel(front * 40.0f32);
 
@@ -388,19 +388,19 @@ impl Testbed {
                     },
                     WindowEvent::Key(Key::Num2, _, Action::Press, _) => {
                         let mut graphics = self.graphics.borrow_mut();
-                        let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5, 0.5));
+                        let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5, 0.5));
                         let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
                         let cam_transform;
 
                         {
                             let cam = graphics.camera();
-                            cam_transform = na::inv(&cam.view_transform()).unwrap();
+                            cam_transform = na::inverse(&cam.view_transform()).unwrap();
                         }
 
                         rb.append_translation(&na::translation(&cam_transform));
 
-                        let front = -na::rotate(&cam_transform, &Vec3::z());
+                        let front = -na::rotate(&cam_transform, &Vector3::z());
 
                         rb.set_lin_vel(front * 40.0f32);
 
@@ -433,13 +433,13 @@ impl Testbed {
                 draw_collisions(&mut self.window, &mut self.world);
             }
 
-            let color = Pnt3::new(1.0, 1.0, 1.0);
+            let color = Point3::new(1.0, 1.0, 1.0);
 
             if running != RunMode::Stop {
-                self.window.draw_text(&format!("Time: {:.*}sec.", 4, dt)[..], &na::orig(), &font, &color);
+                self.window.draw_text(&format!("Time: {:.*}sec.", 4, dt)[..], &na::origin(), &font, &color);
             }
             else {
-                self.window.draw_text("Paused", &na::orig(), &font, &color);
+                self.window.draw_text("Paused", &na::origin(), &font, &color);
             }
 
             self.window.render_with_camera(self.graphics.borrow_mut().camera_mut());
@@ -462,19 +462,19 @@ fn draw_collisions(window: &mut Window, physics: &mut World<f32>) {
     for c in collisions.iter() {
         match *c {
             Constraint::RBRB(_, _, ref c) => {
-                window.draw_line(&c.world1, &c.world2, &Pnt3::new(1.0, 0.0, 0.0));
+                window.draw_line(&c.world1, &c.world2, &Point3::new(1.0, 0.0, 0.0));
 
                 let center = na::center(&c.world1, &c.world2);
                 let end    = center + c.normal * 0.4f32;
-                window.draw_line(&center, &end, &Pnt3::new(0.0, 1.0, 1.0))
+                window.draw_line(&center, &end, &Point3::new(0.0, 1.0, 1.0))
             },
             Constraint::BallInSocket(ref bis) => {
                 let bbis = bis.borrow();
-                window.draw_line(&bbis.anchor1_pos(), &bbis.anchor2_pos(), &Pnt3::new(0.0, 1.0, 0.0));
+                window.draw_line(&bbis.anchor1_pos(), &bbis.anchor2_pos(), &Point3::new(0.0, 1.0, 0.0));
             },
             Constraint::Fixed(ref f) => {
                 // FIXME: draw the rotation too
-                window.draw_line(&f.borrow().anchor1_pos().translate(&na::orig()), &f.borrow().anchor2_pos().translate(&na::orig()), &Pnt3::new(0.0, 1.0, 0.0));
+                window.draw_line(&f.borrow().anchor1_pos().translate(&na::origin()), &f.borrow().anchor2_pos().translate(&na::origin()), &Point3::new(0.0, 1.0, 0.0));
             }
         }
     }

--- a/examples3d/primitives.rs
+++ b/examples3d/primitives.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -61,7 +61,7 @@ fn main() {
 
                 rb.append_translation(&Vec3::new(x, y, z));
 
-                world.add_body(rb);
+                world.add_rigid_body(rb);
             }
         }
     }

--- a/examples3d/primitives.rs
+++ b/examples3d/primitives.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid, Cone, Cylinder, Ball};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -43,7 +43,7 @@ fn main() {
                 let mut rb;
 
                 if j % 4 == 0 {
-                    let geom = Cuboid::new(Vec3::new(rad, rad, rad));
+                    let geom = Cuboid::new(Vector3::new(rad, rad, rad));
                     rb       = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
                 }
                 else if j % 3 == 0 {
@@ -59,7 +59,7 @@ fn main() {
                     rb       = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
                 }
 
-                rb.append_translation(&Vec3::new(x, y, z));
+                rb.append_translation(&Vector3::new(x, y, z));
 
                 world.add_rigid_body(rb);
             }
@@ -71,6 +71,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/pyramid.rs
+++ b/examples3d/pyramid.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -39,9 +39,9 @@ fn main() {
             let x = (fi * shift / 2.0) + fj * shift - centerx;
             let y = fi * shift + centery;
 
-            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
+            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector3::new(rad - 0.04, rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.6);
 
-            rb.append_translation(&Vec3::new(x, y, 0.0));
+            rb.append_translation(&Vector3::new(x, y, 0.0));
 
             world.add_rigid_body(rb);
         }
@@ -52,6 +52,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/pyramid.rs
+++ b/examples3d/pyramid.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -43,7 +43,7 @@ fn main() {
 
             rb.append_translation(&Vec3::new(x, y, 0.0));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples3d/ragdoll.rs
+++ b/examples3d/ragdoll.rs
@@ -4,7 +4,7 @@ extern crate nphysics3d;
 extern crate nalgebra as na;
 
 use std::f32;
-use na::{Pnt3, Vec3, Translation, Rotation};
+use na::{Point3, Vector3, Translation, Rotation};
 use ncollide::shape::{Plane, Ball, Cylinder};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -16,12 +16,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * A plane for the ground
      */
-    let ground_geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let ground_geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
 
@@ -38,7 +38,7 @@ fn main() {
                 let y = j as f32 * shift + 10.0;
                 let z = k as f32 * shift - n as f32 * shift / 2.0;
 
-                add_ragdoll(Vec3::new(x, y, z), &mut world);
+                add_ragdoll(Vector3::new(x, y, z), &mut world);
             }
         }
     }
@@ -48,15 +48,15 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }
 
-fn add_ragdoll(pos: Vec3<f32>, world: &mut World<f32>) {
+fn add_ragdoll(pos: Vector3<f32>, world: &mut World<f32>) {
     // head
     let     head_geom = Ball::new(0.8);
     let mut head      = RigidBody::new_dynamic(head_geom, 1.0, 0.3, 0.5);
-    head.append_translation(&(pos + Vec3::new(0.0, 2.4, 0.0)));
+    head.append_translation(&(pos + Vector3::new(0.0, 2.4, 0.0)));
 
     // body
     let     body_geom = Cylinder::new(1.2, 0.5);
@@ -66,21 +66,21 @@ fn add_ragdoll(pos: Vec3<f32>, world: &mut World<f32>) {
     // right arm
     let     rarm_geom = Cylinder::new(1.6, 0.2);
     let mut rarm      = RigidBody::new_dynamic(rarm_geom, 1.0, 0.3, 0.5);
-    rarm.append_rotation(&Vec3::new(f32::consts::FRAC_PI_2, 0.0, 0.0));
-    rarm.append_translation(&(pos + Vec3::new(0.0, 1.0, 2.4)));
+    rarm.append_rotation(&Vector3::new(f32::consts::FRAC_PI_2, 0.0, 0.0));
+    rarm.append_translation(&(pos + Vector3::new(0.0, 1.0, 2.4)));
 
     // left arm
     let mut larm      = rarm.clone();
-    larm.append_translation(&Vec3::new(0.0, 0.0, -4.8));
+    larm.append_translation(&Vector3::new(0.0, 0.0, -4.8));
 
     // right foot
     let     rfoot_geom = Cylinder::new(1.6, 0.2);
     let mut rfoot      = RigidBody::new_dynamic(rfoot_geom, 1.0, 0.3, 0.5);
-    rfoot.append_translation(&(pos + Vec3::new(0.0, -3.0, 0.4)));
+    rfoot.append_translation(&(pos + Vector3::new(0.0, -3.0, 0.4)));
 
     // left foot
     let mut lfoot      = rfoot.clone();
-    lfoot.append_translation(&Vec3::new(0.0, 0.0, -0.8));
+    lfoot.append_translation(&Vector3::new(0.0, 0.0, -0.8));
 
     let head  = world.add_rigid_body(head);
     let body  = world.add_rigid_body(body);
@@ -92,17 +92,17 @@ fn add_ragdoll(pos: Vec3<f32>, world: &mut World<f32>) {
     /*
      * Create joints.
      */
-    let body_anchor_head  = Anchor::new(Some(body.clone()), Pnt3::new(0.0, 1.5, 0.0));
-    let body_anchor_rarm  = Anchor::new(Some(body.clone()), Pnt3::new(0.0, 1.0, 0.75));
-    let body_anchor_larm  = Anchor::new(Some(body.clone()), Pnt3::new(0.0, 1.0, -0.75));
-    let body_anchor_rfoot = Anchor::new(Some(body.clone()), Pnt3::new(0.0, -1.5, 0.2));
-    let body_anchor_lfoot = Anchor::new(Some(body.clone()), Pnt3::new(0.0, -1.5, -0.2));
+    let body_anchor_head  = Anchor::new(Some(body.clone()), Point3::new(0.0, 1.5, 0.0));
+    let body_anchor_rarm  = Anchor::new(Some(body.clone()), Point3::new(0.0, 1.0, 0.75));
+    let body_anchor_larm  = Anchor::new(Some(body.clone()), Point3::new(0.0, 1.0, -0.75));
+    let body_anchor_rfoot = Anchor::new(Some(body.clone()), Point3::new(0.0, -1.5, 0.2));
+    let body_anchor_lfoot = Anchor::new(Some(body.clone()), Point3::new(0.0, -1.5, -0.2));
 
-    let head_anchor       = Anchor::new(Some(head), Pnt3::new(0.0, -0.9, 0.0));
-    let rarm_anchor       = Anchor::new(Some(rarm), Pnt3::new(0.0, -1.7, 0.0));
-    let larm_anchor       = Anchor::new(Some(larm), Pnt3::new(0.0, 1.7, 0.0));
-    let rfoot_anchor      = Anchor::new(Some(rfoot), Pnt3::new(0.0, 1.7, 0.0));
-    let lfoot_anchor      = Anchor::new(Some(lfoot), Pnt3::new(0.0, 1.7, 0.0));
+    let head_anchor       = Anchor::new(Some(head), Point3::new(0.0, -0.9, 0.0));
+    let rarm_anchor       = Anchor::new(Some(rarm), Point3::new(0.0, -1.7, 0.0));
+    let larm_anchor       = Anchor::new(Some(larm), Point3::new(0.0, 1.7, 0.0));
+    let rfoot_anchor      = Anchor::new(Some(rfoot), Point3::new(0.0, 1.7, 0.0));
+    let lfoot_anchor      = Anchor::new(Some(lfoot), Point3::new(0.0, 1.7, 0.0));
 
     let head_joint  = BallInSocket::new(body_anchor_head,   head_anchor);
     let rarm_joint  = BallInSocket::new(body_anchor_rarm,   rarm_anchor);

--- a/examples3d/ragdoll.rs
+++ b/examples3d/ragdoll.rs
@@ -23,7 +23,7 @@ fn main() {
      */
     let ground_geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
 
-    world.add_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
+    world.add_rigid_body(RigidBody::new_static(ground_geom, 0.3, 0.6));
 
     /*
      * Create the ragdolls
@@ -82,12 +82,12 @@ fn add_ragdoll(pos: Vec3<f32>, world: &mut World<f32>) {
     let mut lfoot      = rfoot.clone();
     lfoot.append_translation(&Vec3::new(0.0, 0.0, -0.8));
 
-    let head  = world.add_body(head);
-    let body  = world.add_body(body);
-    let rarm  = world.add_body(rarm);
-    let larm  = world.add_body(larm);
-    let rfoot = world.add_body(rfoot);
-    let lfoot = world.add_body(lfoot);
+    let head  = world.add_rigid_body(head);
+    let body  = world.add_rigid_body(body);
+    let rarm  = world.add_rigid_body(rarm);
+    let larm  = world.add_rigid_body(larm);
+    let rfoot = world.add_rigid_body(rfoot);
+    let lfoot = world.add_rigid_body(lfoot);
 
     /*
      * Create joints.

--- a/examples3d/sensor.rs
+++ b/examples3d/sensor.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid, Ball};
 use ncollide::geometry::Proximity;
 use ncollide::narrow_phase::ProximitySignalHandler;
@@ -25,8 +25,8 @@ impl ProximitySignalHandler<WorldObject<f32>> for ColorChanger {
                         o1: &WorldObject<f32>, o2: &WorldObject<f32>,
                         _: Proximity, new_proximity: Proximity) {
         let color = match new_proximity {
-            Proximity::WithinMargin | Proximity::Intersecting => Pnt3::new(1.0, 1.0, 0.0),
-            Proximity::Disjoint                               => Pnt3::new(0.5, 0.5, 1.0)
+            Proximity::WithinMargin | Proximity::Intersecting => Point3::new(1.0, 1.0, 0.0),
+            Proximity::Disjoint                               => Point3::new(0.5, 0.5, 1.0)
         };
     
         if let WorldObject::RigidBody(ref rb) = *o1 {
@@ -46,12 +46,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Plane
      */
-    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+    let geom = Plane::new(Vector3::new(0.0, 1.0, 0.0));
 
     world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
 
@@ -69,24 +69,24 @@ fn main() {
             let x = i as f32 * shift - centerx;
             let z = k as f32 * shift - centerz;
 
-            let geom   = Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04));
+            let geom   = Cuboid::new(Vector3::new(rad - 0.04, rad - 0.04, rad - 0.04));
             let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
 
-            rb.append_translation(&Vec3::new(x, 3.0, z));
+            rb.append_translation(&Vector3::new(x, 3.0, z));
 
             let rb_handle = world.add_rigid_body(rb);
-            testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 0.5, 1.0));
+            testbed.set_rigid_body_color(&rb_handle, Point3::new(0.5, 0.5, 1.0));
         }
     }
 
     /*
      * Create a box that will have a sensor attached.
      */
-    let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5, 0.5));
+    let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5, 0.5));
     let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
-    rb.append_translation(&Vec3::new(0.0, 10.0, 0.0));
+    rb.append_translation(&Vector3::new(0.0, 10.0, 0.0));
     let rb_handle = world.add_rigid_body(rb);
-    testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 1.0, 1.0));
+    testbed.set_rigid_body_color(&rb_handle, Point3::new(0.5, 1.0, 1.0));
 
     // Attach a sensor.
     let sensor_geom = Ball::new(rad * 5.0);
@@ -101,6 +101,6 @@ fn main() {
      * Set up the testbed.
      */
     testbed.set_world(world);
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/examples3d/sensor.rs
+++ b/examples3d/sensor.rs
@@ -1,0 +1,106 @@
+extern crate nalgebra as na;
+extern crate ncollide;
+extern crate nphysics3d;
+extern crate nphysics_testbed3d;
+
+use na::{Pnt3, Vec3, Translation};
+use ncollide::shape::{Plane, Cuboid, Ball};
+use ncollide::geometry::Proximity;
+use ncollide::narrow_phase::ProximitySignalHandler;
+use nphysics3d::world::World;
+use nphysics3d::object::{RigidBody, WorldObject};
+use nphysics3d::object::Sensor;
+use nphysics_testbed3d::{Testbed, GraphicsManagerHandle};
+
+/*
+ * A proximity handler that will change the color of a rigid body as it enters of leaves proximity
+ * with the sensor.
+ */
+struct ColorChanger {
+    graphics: GraphicsManagerHandle
+}
+
+impl ProximitySignalHandler<WorldObject<f32>> for ColorChanger {
+    fn handle_proximity(&mut self,
+                        o1: &WorldObject<f32>, o2: &WorldObject<f32>,
+                        _: Proximity, new_proximity: Proximity) {
+        let color = match new_proximity {
+            Proximity::WithinMargin | Proximity::Intersecting => Pnt3::new(1.0, 1.0, 0.0),
+            Proximity::Disjoint                               => Pnt3::new(0.5, 0.5, 1.0)
+        };
+    
+        if let WorldObject::RigidBody(ref rb) = *o1 {
+            self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+        }
+    
+        if let WorldObject::RigidBody(ref rb) = *o2 {
+            self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+        }
+    }
+}
+
+fn main() {
+    let mut testbed = Testbed::new_empty();
+
+    /*
+     * World
+     */
+    let mut world = World::new();
+    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+
+    /*
+     * Plane
+     */
+    let geom = Plane::new(Vec3::new(0.0, 1.0, 0.0));
+
+    world.add_rigid_body(RigidBody::new_static(geom, 0.3, 0.6));
+
+    /*
+     * Create some boxes.
+     */
+    let num     = 15;
+    let rad     = 1.0;
+    let shift   = rad * 2.0;
+    let centerx = shift * (num as f32) / 2.0;
+    let centerz = shift * (num as f32) / 2.0;
+
+    for i in 0usize .. num {
+        for k in 0usize .. num {
+            let x = i as f32 * shift - centerx;
+            let z = k as f32 * shift - centerz;
+
+            let geom   = Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04));
+            let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
+
+            rb.append_translation(&Vec3::new(x, 3.0, z));
+
+            let rb_handle = world.add_rigid_body(rb);
+            testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 0.5, 1.0));
+        }
+    }
+
+    /*
+     * Create a box that will have a sensor attached.
+     */
+    let geom   = Cuboid::new(Vec3::new(0.5f32, 0.5, 0.5));
+    let mut rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.5);
+    rb.append_translation(&Vec3::new(0.0, 10.0, 0.0));
+    let rb_handle = world.add_rigid_body(rb);
+    testbed.set_rigid_body_color(&rb_handle, Pnt3::new(0.5, 1.0, 1.0));
+
+    // Attach a sensor.
+    let sensor_geom = Ball::new(rad * 5.0);
+    let sensor      = Sensor::new(sensor_geom, Some(rb_handle));
+    world.add_sensor(sensor);
+
+    // Setup the callback.
+    let handler = ColorChanger { graphics: testbed.graphics() };
+    world.register_proximity_signal_handler("color_changer", handler);
+
+    /*
+     * Set up the testbed.
+     */
+    testbed.set_world(world);
+    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.run();
+}

--- a/examples3d/wall.rs
+++ b/examples3d/wall.rs
@@ -21,7 +21,7 @@ fn main() {
      */
     let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
-    world.add_body(rb);
+    world.add_rigid_body(rb);
 
     /*
      * Create the boxes
@@ -42,7 +42,7 @@ fn main() {
 
             rb.append_translation(&Vec3::new(x, y, 0.0));
 
-            world.add_body(rb);
+            world.add_rigid_body(rb);
         }
     }
 

--- a/examples3d/wall.rs
+++ b/examples3d/wall.rs
@@ -3,7 +3,7 @@ extern crate ncollide;
 extern crate nphysics3d;
 extern crate nphysics_testbed3d;
 
-use na::{Pnt3, Vec3, Translation};
+use na::{Point3, Vector3, Translation};
 use ncollide::shape::{Plane, Cuboid};
 use nphysics3d::world::World;
 use nphysics3d::object::RigidBody;
@@ -14,12 +14,12 @@ fn main() {
      * World
      */
     let mut world = World::new();
-    world.set_gravity(Vec3::new(0.0, -9.81, 0.0));
+    world.set_gravity(Vector3::new(0.0, -9.81, 0.0));
 
     /*
      * Planes
      */
-    let rb = RigidBody::new_static(Plane::new(Vec3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
+    let rb = RigidBody::new_static(Plane::new(Vector3::new(0.0, 1.0, 0.0)), 0.3, 0.6);
 
     world.add_rigid_body(rb);
 
@@ -38,9 +38,9 @@ fn main() {
             let x = i as f32 * shift - centerx;
             let y = j as f32 * shift + centery;
 
-            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vec3::new(rad - 0.04, rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.5);
+            let mut rb = RigidBody::new_dynamic(Cuboid::new(Vector3::new(rad - 0.04, rad - 0.04, rad - 0.04)), 1.0, 0.3, 0.5);
 
-            rb.append_translation(&Vec3::new(x, y, 0.0));
+            rb.append_translation(&Vector3::new(x, y, 0.0));
 
             world.add_rigid_body(rb);
         }
@@ -51,6 +51,6 @@ fn main() {
      */
     let mut testbed = Testbed::new(world);
 
-    testbed.look_at(Pnt3::new(-30.0, 30.0, -30.0), Pnt3::new(0.0, 0.0, 0.0));
+    testbed.look_at(Point3::new(-30.0, 30.0, -30.0), Point3::new(0.0, 0.0, 0.0));
     testbed.run();
 }

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -52,7 +52,7 @@ impl<N: Scalar> ActivationManager<N> {
                 // FIXME: take the time in account (to make a true RWA)
                 let _1         = na::one::<N>();
                 let new_energy = (_1 - self.mix_factor) * b.activation_state().energy() +
-                    self.mix_factor * (na::sqnorm(&b.lin_vel()) + na::sqnorm(&b.ang_vel()));
+                    self.mix_factor * (na::norm_squared(&b.lin_vel()) + na::norm_squared(&b.ang_vel()));
 
                 b.activate(new_energy.min(threshold * na::cast::<f64, N>(4.0f64)));
             },

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -7,7 +7,7 @@ use ncollide::utils::data::hash::UintTWHash;
 use world::RigidBodyCollisionWorld;
 use detection::constraint::Constraint;
 use detection::joint::{JointManager, Joint};
-use object::{RigidBody, RigidBodyHandle, ActivationState};
+use object::{WorldObject, RigidBody, RigidBodyHandle, ActivationState};
 use utils::union_find::UnionFindSet;
 use utils::union_find;
 
@@ -133,8 +133,10 @@ impl<N: Scalar> ActivationManager<N> {
         }
 
         for (b1, b2, cd) in world.contact_pairs() {
-            if cd.num_colls() != 0 {
-                make_union(&b1.data, &b2.data, &mut self.ufind[..])
+            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
+                if cd.num_colls() != 0 {
+                    make_union(&rb1, &rb2, &mut self.ufind[..])
+                }
             }
         }
 

--- a/src/detection/joint/anchor.rs
+++ b/src/detection/joint/anchor.rs
@@ -37,7 +37,7 @@ impl<N: Scalar, P> Anchor<N, P> {
 
                 rb.center_of_mass().clone()
             },
-            None => na::orig()
+            None => na::origin()
         }
     }
 }

--- a/src/detection/joint/joint_manager.rs
+++ b/src/detection/joint/joint_manager.rs
@@ -223,7 +223,7 @@ impl<N: Scalar> JointManager<N> {
     }
 
     /// Collects all the constraints caused by joints.
-    pub fn interferences(&mut self, constraint: &mut Vec<Constraint<N>>) {
+    pub fn constraints(&mut self, constraint: &mut Vec<Constraint<N>>) {
         for joint in self.joints.elements().iter() {
             constraint.push(joint.value.clone())
         }

--- a/src/integration/euler.rs
+++ b/src/integration/euler.rs
@@ -58,7 +58,7 @@ pub fn semi_implicit_integrate_wo_rotation<N: Scalar>(dt: N, p: &Point<N>, lv: &
 pub fn displacement<N: Scalar>(dt: N, _: &Matrix<N>, center_of_mass: &Point<N>,
                                lin_vel: &Vector<N>, ang_vel: &Orientation<N>) -> Matrix<N> {
     let mut res: Matrix<N> = na::one();
-    res.append_rotation_wrt_point_mut(&(*ang_vel * dt), center_of_mass.as_vec());
+    res.append_rotation_wrt_point_mut(&(*ang_vel * dt), center_of_mass.as_vector());
 
     res.append_translation_mut(&(*lin_vel * dt));
 

--- a/src/integration/translational_ccd_motion_clamping.rs
+++ b/src/integration/translational_ccd_motion_clamping.rs
@@ -24,7 +24,7 @@ struct CCDRigidBody<N: Scalar> {
 
 impl<N: Scalar> CCDRigidBody<N> {
     fn new(rigid_body: RigidBodyHandle<N>, threshold: N, trigger_sensors: bool) -> CCDRigidBody<N> {
-        let last_center = rigid_body.borrow().position().translation().to_pnt();
+        let last_center = rigid_body.borrow().position().translation().to_point();
 
         CCDRigidBody {
             sqthreshold:     threshold * threshold,
@@ -78,9 +78,9 @@ impl<N: Scalar> TranslationalCCDMotionClamping<N> {
         for co1 in self.objects.elements_mut().iter_mut() {
             let mut obj1 = co1.value.rigid_body.borrow_mut();
 
-            let movement = *obj1.position().translation().as_pnt() - co1.value.last_center;
+            let movement = *obj1.position().translation().as_point() - co1.value.last_center;
 
-            if na::sqnorm(&movement) > co1.value.sqthreshold {
+            if na::norm_squared(&movement) > co1.value.sqthreshold {
                 // Use CCD for this object.
                 let obj1_uid = &*co1.value.rigid_body as *const RefCell<RigidBody<N>> as usize;
 
@@ -177,7 +177,7 @@ impl<N: Scalar> TranslationalCCDMotionClamping<N> {
                 // }
             }
 
-            co1.value.last_center = obj1.position().translation().to_pnt();
+            co1.value.last_center = obj1.position().translation().to_point();
             self.intersected_sensors_cache.clear();
         }
 

--- a/src/integration/translational_ccd_motion_clamping.rs
+++ b/src/integration/translational_ccd_motion_clamping.rs
@@ -85,8 +85,8 @@ impl<N: Scalar> TranslationalCCDMotionClamping<N> {
                 let obj1_uid = &*co1.value.rigid_body as *const RefCell<RigidBody<N>> as usize;
 
                 let last_transform = na::append_translation(obj1.position(), &-movement);
-                let begin_aabb     = bounding_volume::aabb(obj1.shape_ref(), &last_transform);
-                let end_aabb       = bounding_volume::aabb(obj1.shape_ref(), obj1.position());
+                let begin_aabb     = bounding_volume::aabb(obj1.shape().as_ref(), &last_transform);
+                let end_aabb       = bounding_volume::aabb(obj1.shape().as_ref(), obj1.position());
                 let swept_aabb     = begin_aabb.merged(&end_aabb);
 
                 /*
@@ -109,10 +109,10 @@ impl<N: Scalar> TranslationalCCDMotionClamping<N> {
                         let toi = geometry::time_of_impact(
                             &last_transform,
                             &dir,
-                            obj1.shape_ref(),
+                            obj1.shape().as_ref(),
                             &obj2.position(),
                             &na::zero(), // Assume the other object does not move.
-                            obj2.shape_ref());
+                            obj2.shape().as_ref());
 
                         match toi {
                             Some(t) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,47 +116,47 @@ mod tests;
 /// Compilation flags dependent aliases for mathematical types.
 #[cfg(feature = "dim3")]
 pub mod math {
-    use na::{Pnt3, Vec3, Mat3, Rot3, Iso3};
+    use na::{Point3, Vector3, Matrix3, Rotation3, Isometry3};
 
     /// The point type.
-    pub type Point<N> = Pnt3<N>;
+    pub type Point<N> = Point3<N>;
 
     /// The vector type.
-    pub type Vector<N> = Vec3<N>;
+    pub type Vector<N> = Vector3<N>;
 
     /// The orientation type.
-    pub type Orientation<N> = Vec3<N>;
+    pub type Orientation<N> = Vector3<N>;
 
     /// The transformation matrix type.
-    pub type Matrix<N> = Iso3<N>;
+    pub type Matrix<N> = Isometry3<N>;
 
     /// The rotation matrix type.
-    pub type RotationMatrix<N> = Rot3<N>;
+    pub type RotationMatrix<N> = Rotation3<N>;
 
     /// The inertia tensor type.
-    pub type AngularInertia<N> = Mat3<N>;
+    pub type AngularInertia<N> = Matrix3<N>;
 }
 
 /// Compilation flags dependent aliases for mathematical types.
 #[cfg(feature = "dim2")]
 pub mod math {
-    use na::{Pnt2, Vec1, Vec2, Mat1, Rot2, Iso2};
+    use na::{Point2, Vector1, Vector2, Matrix1, Rotation2, Isometry2};
 
     /// The point type.
-    pub type Point<N> = Pnt2<N>;
+    pub type Point<N> = Point2<N>;
 
     /// The vector type.
-    pub type Vector<N> = Vec2<N>;
+    pub type Vector<N> = Vector2<N>;
 
     /// The orientation type.
-    pub type Orientation<N> = Vec1<N>;
+    pub type Orientation<N> = Vector1<N>;
 
     /// The transformation matrix type.
-    pub type Matrix<N> = Iso2<N>;
+    pub type Matrix<N> = Isometry2<N>;
 
     /// The rotation matrix type.
-    pub type RotationMatrix<N> = Rot2<N>;
+    pub type RotationMatrix<N> = Rotation2<N>;
 
     /// The inertia tensor type.
-    pub type AngularInertia<N> = Mat1<N>;
+    pub type AngularInertia<N> = Matrix1<N>;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,15 +50,16 @@ Use `make examples` to build the demos and execute `./your_favorite_example_here
 to see all the cool stuffs you can do.
 
 ## Features
-- static and dynamic rigid bodies
-- common convex primitives: cone, box, ball, cylinder
-- concave geometries build from convex primitives (aka. compound geometries)
-- stable stacking
-- island based sleeping (objects deactivation)
-- ray casting
-- swept sphere based continuous collision detection
-- ball-in-socket joint
-- fixed joint
+- Static and dynamic rigid bodies.
+- Common convex primitives: cone, box, ball, cylinder.
+- Concave geometries build from convex primitives (aka. compound geometries).
+- Stable stacking.
+- Island based sleeping (objects deactivation).
+- Ray casting.
+- Swept sphere based continuous collision detection.
+- Ball-in-socket joint.
+- Fixed joint.
+- Sensors.
 
 ## What is missing?
 **nphysics** is a very young library and needs to learn a lot of things to

--- a/src/object/collision_groups_wrapper_impl.rs
+++ b/src/object/collision_groups_wrapper_impl.rs
@@ -1,0 +1,173 @@
+#![macro_use]
+
+/// Reserved group id for static rigid bodies.
+pub const STATIC_GROUP_ID: usize = 29;
+/// Reserved group id for sensors.
+pub const SENSOR_GROUP_ID: usize = 28;
+
+macro_rules! collision_groups_wrapper_impl(
+    ($t: ident) => (
+        impl $t {
+            /// Return the internal, ncollide-compatible, `CollisionGroups`
+            #[inline]
+            pub fn as_collision_groups(&self) -> &CollisionGroups {
+                &self.collision_groups
+            }
+
+            /// Adds or removes this entity from the given group.
+            #[inline]
+            pub fn modify_membership(&mut self, group_id: usize, add: bool) {
+                assert!(group_id != STATIC_GROUP_ID, "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(group_id != SENSOR_GROUP_ID, "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                self.collision_groups.modify_membership(group_id, add);
+            }
+
+            /// Adds or removes the given group from this entity whitelist.
+            #[inline]
+            pub fn modify_whitelist(&mut self, group_id: usize, add: bool) {
+                assert!(group_id != STATIC_GROUP_ID, "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(group_id != SENSOR_GROUP_ID, "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                self.collision_groups.modify_whitelist(group_id, add);
+            }
+
+            /// Adds or removes this entity from the given group.
+            #[inline]
+            pub fn modify_blacklist(&mut self, group_id: usize, add: bool) {
+                assert!(group_id != STATIC_GROUP_ID, "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(group_id != SENSOR_GROUP_ID, "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                self.collision_groups.modify_blacklist(group_id, add);
+            }
+
+            /// Make this object member of the given groups only.
+            #[inline]
+            pub fn set_membership(&mut self, groups: &[usize]) {
+                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.set_membership(groups);
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Whitelists the given groups only (others will be un-whitelisted).
+            #[inline]
+            pub fn set_whitelist(&mut self, groups: &[usize]) {
+                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.set_whitelist(groups);
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Blacklists the given groups only (others will be un-blacklisted).
+            #[inline]
+            pub fn set_blacklist(&mut self, groups: &[usize]) {
+                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.set_blacklist(groups);
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Copies the membership of another collision groups.
+            #[inline]
+            pub fn copy_membership(&mut self, other: &$t) {
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.copy_membership(other.as_collision_groups());
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Copies the whitelist of another collision groups.
+            #[inline]
+            pub fn copy_whitelist(&mut self, other: &$t) {
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.copy_whitelist(other.as_collision_groups());
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Copies the blacklist of another collision groups.
+            #[inline]
+            pub fn copy_blacklist(&mut self, other: &$t) {
+                let is_dynamic = self.is_dynamic();
+                self.collision_groups.copy_blacklist(other.as_collision_groups());
+                self.configure_reserved_flags(is_dynamic);
+            }
+
+            /// Un-blacklists static objects.
+            pub fn enable_collision_with_static(&mut self) {
+                self.collision_groups.modify_blacklist(STATIC_GROUP_ID, false);
+                self.collision_groups.modify_whitelist(STATIC_GROUP_ID, true);
+            }
+
+            /// Blacklists any static object.
+            pub fn disable_collision_with_static(&mut self) {
+                self.collision_groups.modify_blacklist(STATIC_GROUP_ID, true);
+                self.collision_groups.modify_whitelist(STATIC_GROUP_ID, false);
+            }
+
+            /// Un-blacklists sensors.
+            pub fn enable_collision_with_sensors(&mut self) {
+                self.collision_groups.modify_blacklist(SENSOR_GROUP_ID, false);
+                self.collision_groups.modify_whitelist(SENSOR_GROUP_ID, true);
+            }
+
+            /// Blacklists sensors.
+            pub fn disable_collision_with_sensors(&mut self) {
+                self.collision_groups.modify_blacklist(SENSOR_GROUP_ID, true);
+                self.collision_groups.modify_whitelist(SENSOR_GROUP_ID, false);
+            }
+
+            /// Enables self collision detection.
+            #[inline]
+            pub fn enable_self_collision(&mut self) {
+                self.collision_groups.enable_self_collision();
+            }
+
+            /// Disables self collision detection.
+            #[inline]
+            pub fn disable_self_collision(&mut self) {
+                self.collision_groups.disable_self_collision();
+            }
+
+            /// Tests if this entity is part of the given group.
+            #[inline]
+            pub fn is_member_of(&self, group_id: usize) -> bool {
+                self.collision_groups.is_member_of(group_id)
+            }
+
+            /// Tests if the given group is whitelisted.
+            #[inline]
+            pub fn is_group_whitelisted(&self, group_id: usize) -> bool {
+                self.collision_groups.is_group_whitelisted(group_id)
+            }
+
+            /// Tests if the given group is blacklisted.
+            #[inline]
+            pub fn is_group_blacklisted(&self, group_id: usize) -> bool {
+                self.collision_groups.is_group_blacklisted(group_id)
+            }
+
+            /// Tests whether collisions with a given group is possible.
+            ///
+            /// Collision is possible if `group_id` is whitelisted but not blacklisted.
+            #[inline]
+            pub fn can_collide_with(&self, group_id: usize) -> bool {
+                self.collision_groups.can_collide_with(group_id)
+            }
+
+            /// Tests whether two collision groups have at least one group in common.
+            #[inline]
+            pub fn can_collide_with_groups(&self, other: &CollisionGroups) -> bool {
+                self.collision_groups.can_collide_with_groups(other)
+            }
+
+            /// Tests whether self-collision is enabled.
+            #[inline]
+            pub fn can_collide_with_self(&self) -> bool {
+                self.collision_groups.can_collide_with_self()
+            }
+        }
+    )
+);

--- a/src/object/collision_groups_wrapper_impl.rs
+++ b/src/object/collision_groups_wrapper_impl.rs
@@ -8,6 +8,12 @@ pub const SENSOR_GROUP_ID: usize = 28;
 macro_rules! collision_groups_wrapper_impl(
     ($t: ident) => (
         impl $t {
+            /// The maximum allowed group identifier.
+            #[inline]
+            pub fn max_group_id() -> usize {
+                27
+            }
+
             /// Return the internal, ncollide-compatible, `CollisionGroups`
             #[inline]
             pub fn as_collision_groups(&self) -> &CollisionGroups {
@@ -41,8 +47,8 @@ macro_rules! collision_groups_wrapper_impl(
             /// Make this object member of the given groups only.
             #[inline]
             pub fn set_membership(&mut self, groups: &[usize]) {
-                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
-                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                assert!(!groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(!groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
 
                 let is_dynamic = self.is_dynamic();
                 self.collision_groups.set_membership(groups);
@@ -52,8 +58,8 @@ macro_rules! collision_groups_wrapper_impl(
             /// Whitelists the given groups only (others will be un-whitelisted).
             #[inline]
             pub fn set_whitelist(&mut self, groups: &[usize]) {
-                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
-                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                assert!(!groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(!groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
 
                 let is_dynamic = self.is_dynamic();
                 self.collision_groups.set_whitelist(groups);
@@ -63,8 +69,8 @@ macro_rules! collision_groups_wrapper_impl(
             /// Blacklists the given groups only (others will be un-blacklisted).
             #[inline]
             pub fn set_blacklist(&mut self, groups: &[usize]) {
-                assert!(groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
-                assert!(groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
+                assert!(!groups.contains(&STATIC_GROUP_ID), "The static group {} is reserved.", STATIC_GROUP_ID);
+                assert!(!groups.contains(&SENSOR_GROUP_ID), "The sensor group {} is reserved.", SENSOR_GROUP_ID);
 
                 let is_dynamic = self.is_dynamic();
                 self.collision_groups.set_blacklist(groups);

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,7 +1,15 @@
-//! Rigid bodies.
+//! Objects that may be added to the physical world.
+
+pub use self::rigid_body::{RigidBody, RigidBodyHandle, ActivationState, RigidBodyState};
+pub use self::sensor::{Sensor, SensorHandle};
+pub use self::world_object::{WorldObject, WorldObjectBorrowed, WorldObjectBorrowedMut};
+pub use self::rigid_body_collision_groups::RigidBodyCollisionGroups;
+pub use self::sensor_collision_groups::SensorCollisionGroups;
+pub use self::collision_groups_wrapper_impl::{STATIC_GROUP_ID, SENSOR_GROUP_ID};
 
 mod rigid_body;
+mod sensor;
+mod world_object;
+mod collision_groups_wrapper_impl;
 mod rigid_body_collision_groups;
-
-pub use object::rigid_body::{RigidBody, RigidBodyHandle, ActivationState, RigidBodyState};
-pub use object::rigid_body_collision_groups::RigidBodyCollisionGroups;
+mod sensor_collision_groups;

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -632,6 +632,15 @@ impl<N: Scalar> RigidBody<N> {
     /// Set the new collisions groups of this rigid body.
     #[inline]
     pub fn set_collision_groups(&mut self, new_groups: RigidBodyCollisionGroups) {
+        if self.can_move() && new_groups.is_static() {
+            panic!("Attempted to assign collision groups for static rigid bodies to a dynamic rigid body. \
+                    TIP: use RigidBodyCollisionGroups::new_dynamic() to create one.");
+        }
+        if !self.can_move() && new_groups.is_dynamic() {
+            panic!("Attempted to assign collision groups for dynamic rigid bodies to a static rigid body. \
+                    TIP: use RigidBodyCollisionGroups::new_static() to create one.");
+        }
+
         self.collision_groups = new_groups;
     }
 

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -356,7 +356,8 @@ impl<N: Scalar> RigidBody<N> {
     /// Sets the linear acceleration scale of this rigid body.
     #[inline]
     pub fn set_lin_acc_scale(&mut self, scale: Vector<N>) {
-        self.lin_acc_scale = scale
+        self.lin_acc_scale = scale;
+        self.update_lin_acc();
     }
 
     /// Gets the angular acceleration scale of this rigid body.
@@ -368,7 +369,8 @@ impl<N: Scalar> RigidBody<N> {
     /// Sets the angular acceleration scale of this rigid body.
     #[inline]
     pub fn set_ang_acc_scale(&mut self, scale: Orientation<N>) {
-        self.ang_acc_scale = scale
+        self.ang_acc_scale = scale;
+        self.update_ang_acc();
     }
 
     /// Get the linear velocity of this rigid body.
@@ -392,9 +394,9 @@ impl<N: Scalar> RigidBody<N> {
     /// Sets the linear acceleration of this rigid body.
     ///
     /// Note that this might be reset by the physics engine automatically.
-    #[inline]
+    #[doc(hidden)]
     pub fn set_lin_acc(&mut self, lf: Vector<N>) {
-        self.lin_acc = lf * self.lin_acc_scale
+        self.lin_acc = lf
     }
 
     /// Gets the angular velocity of this rigid body.
@@ -418,9 +420,9 @@ impl<N: Scalar> RigidBody<N> {
     /// Sets the angular acceleration of this rigid body.
     ///
     /// Note that this might be reset by the physics engine automatically.
-    #[inline]
+    #[doc(hidden)]
     pub fn set_ang_acc(&mut self, af: Orientation<N>) {
-        self.ang_acc = af * self.ang_acc_scale
+        self.ang_acc = af
     }
 
     /// Sets the gravity for this RigidBody. It's internally called from BodyForceGenerator,
@@ -486,12 +488,12 @@ impl<N: Scalar> RigidBody<N> {
     /// Update the linear acceleraction from the applied forces.
     #[inline]
     fn update_lin_acc(&mut self) {
-        self.lin_acc = self.lin_force * self.inv_mass + self.gravity;
+        self.lin_acc = (self.lin_force * self.inv_mass + self.gravity) * self.lin_acc_scale;
     }
     /// Update the angular acceleraction from the applied forces.
     #[inline]
     fn update_ang_acc(&mut self) {
-        self.ang_acc = self.ang_force * self.inv_inertia;
+        self.ang_acc = (self.ang_force * self.inv_inertia) * self.ang_acc_scale;
     }
 
     /// Applies a one-time central impulse.
@@ -499,7 +501,7 @@ impl<N: Scalar> RigidBody<N> {
     pub fn apply_central_impulse(&mut self, impulse: Vector<N>){
         let current_velocity = self.lin_vel();
         let inverted_mass = self.inv_mass();
-        self.set_lin_vel(current_velocity + impulse*inverted_mass);
+        self.set_lin_vel(current_velocity + impulse * inverted_mass);
     }
 
     /// Applies a one-time angular impulse.

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -284,7 +284,7 @@ impl<N: Scalar> RigidBody<N> {
                -> RigidBody<N> {
         let (inv_mass, center_of_mass, inv_inertia, active, state, groups) =
             match mass_properties {
-                None => (na::zero(), na::orig(), na::zero(), ActivationState::Inactive, RigidBodyState::Static, RigidBodyCollisionGroups::new_static()),
+                None => (na::zero(), na::origin(), na::zero(), ActivationState::Inactive, RigidBodyState::Static, RigidBodyCollisionGroups::new_static()),
                 Some((mass, com, inertia)) => {
                     if na::is_zero(&mass) {
                         panic!("A dynamic body must not have a zero volume.")
@@ -292,7 +292,7 @@ impl<N: Scalar> RigidBody<N> {
 
                     let ii: AngularInertia<N>;
 
-                    match na::inv(&inertia) {
+                    match na::inverse(&inertia) {
                         Some(i) => ii = i,
                         None    => ii = na::zero()
                     }
@@ -314,7 +314,7 @@ impl<N: Scalar> RigidBody<N> {
                 ls_inv_inertia:    inv_inertia.clone(),
                 inv_inertia:       inv_inertia,
                 ls_center_of_mass: center_of_mass,
-                center_of_mass:    na::orig(),
+                center_of_mass:    na::origin(),
                 lin_acc:           na::zero(),
                 ang_acc:           na::zero(),
                 gravity:           na::zero(),

--- a/src/object/rigid_body_collision_groups.rs
+++ b/src/object/rigid_body_collision_groups.rs
@@ -1,7 +1,5 @@
 use ncollide::world::CollisionGroups;
-
-// internal reserved static group id
-const STATIC_GROUP_ID: usize = 29;
+use object::{STATIC_GROUP_ID, SENSOR_GROUP_ID};
 
 /// Groups of collision used to filter which object collide with which other one.
 /// nphysics use a specific group for its own purposes (i.e. the group of static objects).
@@ -17,107 +15,62 @@ impl RigidBodyCollisionGroups {
     #[inline]
     pub fn new_dynamic() -> RigidBodyCollisionGroups {
 
-        // all memberships + all whitelists activated
+        // All memberships + all whitelists activated.
         let mut groups = CollisionGroups::new();
 
         groups.modify_membership(STATIC_GROUP_ID, false);
+        groups.modify_membership(SENSOR_GROUP_ID, false);
         groups.modify_whitelist(STATIC_GROUP_ID, false);
+        groups.modify_whitelist(SENSOR_GROUP_ID, false);
 
         RigidBodyCollisionGroups{
             collision_groups: groups
         }
     }
 
-    /// Creates a new `RigidBodyCollisionGroups` that enables collisions with everything except
-    /// self-collision.
+    /// Creates a new `RigidBodyCollisionGroups` that enables collisions with every user-defined
+    /// groups. Static objects and sensors are blacklisted by default and self-collision disabled.
     #[inline]
     pub fn new_static() -> RigidBodyCollisionGroups {
 
         // all memberships + all whitelists activated
         let mut groups = CollisionGroups::new();
 
-        groups.modify_whitelist(STATIC_GROUP_ID, false);
+        groups.modify_membership(STATIC_GROUP_ID, true);
+        groups.modify_membership(SENSOR_GROUP_ID, false);
+        groups.modify_whitelist(STATIC_GROUP_ID,  false);
+        groups.modify_whitelist(SENSOR_GROUP_ID,  false);
+
         groups.modify_blacklist(STATIC_GROUP_ID, true);
+        groups.modify_blacklist(SENSOR_GROUP_ID, true);
 
         RigidBodyCollisionGroups{
             collision_groups: groups
         }
     }
 
-    /// Return the internal `CollisionGroups`
-    #[inline]
-    pub fn as_collision_groups(&self) -> &CollisionGroups {
-        &self.collision_groups
+    fn configure_reserved_flags(&mut self, is_dynamic: bool) {
+        if is_dynamic {
+            self.collision_groups.modify_membership(STATIC_GROUP_ID, false);
+            self.collision_groups.modify_membership(SENSOR_GROUP_ID, false);
+        }
+        else {
+            self.collision_groups.modify_membership(STATIC_GROUP_ID, true);
+            self.collision_groups.modify_membership(SENSOR_GROUP_ID, false);
+        }
     }
 
-    /// Adds or removes this entity from the given group.
+    /// Returns `true` if this object is not part of the static group.
     #[inline]
-    pub fn modify_membership(&mut self, group_id: usize, add: bool) {
-        assert!(group_id != STATIC_GROUP_ID, "The group {} is reserved.", STATIC_GROUP_ID);
-        self.collision_groups.modify_membership(group_id, add);
+    pub fn is_dynamic(&self) -> bool {
+        !self.is_member_of(STATIC_GROUP_ID)
     }
 
-    /// Adds or removes the given group from this entity whitelist.
+    /// Returns `true` if this object is part of the static group.
     #[inline]
-    pub fn modify_whitelist(&mut self, group_id: usize, add: bool) {
-        assert!(group_id != STATIC_GROUP_ID, "The group {} is reserved.", STATIC_GROUP_ID);
-        self.collision_groups.modify_whitelist(group_id, add);
-    }
-
-    /// Adds or removes this entity from the given group.
-    #[inline]
-    pub fn modify_blacklist(&mut self, group_id: usize, add: bool) {
-        assert!(group_id != STATIC_GROUP_ID, "The group {} is reserved.", STATIC_GROUP_ID);
-        self.collision_groups.modify_blacklist(group_id, add);
-    }
-
-    /// Enables self collision detection.
-    #[inline]
-    pub fn enable_self_collision(&mut self) {
-        self.collision_groups.enable_self_collision();
-    }
-
-    /// Disables self collision detection.
-    #[inline]
-    pub fn disable_self_collision(&mut self) {
-        self.collision_groups.disable_self_collision();
-    }
-
-    /// Tests if this entity is part of the given group.
-    #[inline]
-    pub fn is_member_of(&self, group_id: usize) -> bool {
-        self.collision_groups.is_member_of(group_id)
-    }
-
-    /// Tests if the given group is whitelisted.
-    #[inline]
-    pub fn is_group_whitelisted(&self, group_id: usize) -> bool {
-        self.collision_groups.is_group_whitelisted(group_id)
-    }
-
-    /// Tests if the given group is blacklisted.
-    #[inline]
-    pub fn is_group_blacklisted(&self, group_id: usize) -> bool {
-        self.collision_groups.is_group_blacklisted(group_id)
-    }
-
-    /// Tests whether collisions with a given group is possible.
-    ///
-    /// Collision is possible if `group_id` is whitelisted but not blacklisted.
-    #[inline]
-    pub fn can_collide_with(&self, group_id: usize) -> bool {
-        self.collision_groups.can_collide_with(group_id)
-    }
-
-    /// Tests whether two collision groups have at least one group in common.
-    #[inline]
-    pub fn can_collide_with_groups(&self, other: &CollisionGroups) -> bool {
-        self.collision_groups.can_collide_with_groups(other)
-    }
-
-    /// Tests whether self-collision is enabled.
-    #[inline]
-    pub fn can_collide_with_self(&self) -> bool {
-        self.collision_groups.can_collide_with_self()
+    pub fn is_static(&self) -> bool {
+        self.is_member_of(STATIC_GROUP_ID)
     }
 }
+
+collision_groups_wrapper_impl!(RigidBodyCollisionGroups);

--- a/src/object/rigid_body_collision_groups.rs
+++ b/src/object/rigid_body_collision_groups.rs
@@ -4,7 +4,7 @@ use object::{STATIC_GROUP_ID, SENSOR_GROUP_ID};
 /// Groups of collision used to filter which object collide with which other one.
 /// nphysics use a specific group for its own purposes (i.e. the group of static objects).
 /// The `group 29` is reserved and you cannot use it.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct RigidBodyCollisionGroups {
     collision_groups: CollisionGroups
 }
@@ -32,7 +32,6 @@ impl RigidBodyCollisionGroups {
     /// groups. Static objects and sensors are blacklisted by default and self-collision disabled.
     #[inline]
     pub fn new_static() -> RigidBodyCollisionGroups {
-
         // all memberships + all whitelists activated
         let mut groups = CollisionGroups::new();
 

--- a/src/object/sensor.rs
+++ b/src/object/sensor.rs
@@ -119,7 +119,7 @@ impl<N: Scalar> Sensor<N> {
     pub fn set_position(&mut self, abs_pos: Matrix<N>) {
         match self.parent {
             Some(ref rb) => {
-                self.relative_position = na::inv(rb.borrow().position()).unwrap() * abs_pos
+                self.relative_position = na::inverse(rb.borrow().position()).unwrap() * abs_pos
             }
             None => self.relative_position = abs_pos
         }
@@ -130,8 +130,8 @@ impl<N: Scalar> Sensor<N> {
     #[inline]
     pub fn center(&self) -> Point<N> {
         match self.parent {
-            Some(ref rb) => *rb.borrow().position() * na::translation(&self.relative_position).to_pnt(),
-            None         => na::translation(&self.relative_position).to_pnt()
+            Some(ref rb) => *rb.borrow().position() * na::translation(&self.relative_position).to_point(),
+            None         => na::translation(&self.relative_position).to_point()
         }
     }
 

--- a/src/object/sensor.rs
+++ b/src/object/sensor.rs
@@ -1,0 +1,182 @@
+use std::mem;
+use std::any::Any;
+use std::rc::Rc;
+use std::cell::RefCell;
+use std::sync::Arc;
+use na;
+use ncollide::math::Scalar;
+use ncollide::inspection::Repr;
+use ncollide::world::CollisionShapeHandle;
+use math::{Point, Matrix};
+use object::{RigidBodyHandle, SensorCollisionGroups};
+
+/// A shared, mutable, sensor.
+pub type SensorHandle<N> = Rc<RefCell<Sensor<N>>>;
+
+/// An object capable of detecting interferances with other entities without interacting with them.
+pub struct Sensor<N: Scalar> {
+    parent:              Option<RigidBodyHandle<N>>,
+    relative_position:   Matrix<N>,
+    shape:               CollisionShapeHandle<Point<N>, Matrix<N>>, // FIXME: define our own trait.
+    margin:              N,
+    collision_groups:    SensorCollisionGroups,
+    parent_prox:         bool,
+    user_data:           Option<Box<Any>>,
+    interfering_bodies:  Vec<RigidBodyHandle<N>>,
+    interfering_sensors: Vec<SensorHandle<N>>
+}
+
+impl<N: Scalar> Sensor<N> {
+    /// Creates a new sensor.
+    ///
+    /// A sensor may either be attached to the rigid body `parent`, or be attached to the ground.
+    /// If it has a parent, it will have a position relative to it. If the parent moves, the sensor
+    /// will automatically move as well. By default, a sensor does not trigger any proximity event
+    /// when it intersects its own parent.
+    ///
+    /// A sensor has a default margin equal to zero.
+    pub fn new<G>(shape: G, parent: Option<RigidBodyHandle<N>>) -> Sensor<N>
+        where G: Send + Sync + Repr<Point<N>, Matrix<N>> {
+        Sensor {
+            parent:              parent,
+            relative_position:   na::one(),
+            shape:               Arc::new(Box::new(shape)),
+            margin:              na::zero(),
+            collision_groups:    SensorCollisionGroups::new(),
+            parent_prox:         false,
+            user_data:           None,
+            interfering_bodies:  Vec::new(),
+            interfering_sensors: Vec::new()
+        }
+    }
+
+    /// Reference to user-defined data attached to this sensor.
+    #[inline]
+    pub fn user_data(&self) -> Option<&Box<Any>> {
+        self.user_data.as_ref()
+    }
+
+    /// Mutable reference to user-defined data attached to this sensor.
+    #[inline]
+    pub fn user_data_mut(&mut self) -> Option<&mut Box<Any>> {
+        self.user_data.as_mut()
+    }
+
+    /// Attach some user-defined data to this sensor and return the old one.
+    pub fn set_user_data(&mut self, user_data: Option<Box<Any>>) -> Option<Box<Any>> {
+        mem::replace(&mut self.user_data, user_data)
+    }
+
+    /// List of rigid bodies geometrically intersecting this sensor.
+    #[inline]
+    pub fn interfering_bodies(&self) -> &[RigidBodyHandle<N>] {
+        &self.interfering_bodies[..]
+    }
+
+    /// List of sensors geometrically intersecting this sensor.
+    #[inline]
+    pub fn interfering_sensors(&self) -> &[SensorHandle<N>] {
+        &self.interfering_sensors[..]
+    }
+
+    /// This sensor's position relative to `self.parent()`.
+    ///
+    /// If this sensor has no parent, then this relative position is actually the sensor absolute
+    /// position.
+    #[inline]
+    pub fn relative_position(&self) -> &Matrix<N> {
+        &self.relative_position
+    }
+
+    /// Sets the sensor position relative to `self.parent()`.
+    ///
+    /// If `self.parent()` is `None`, then this sets the sensor's absolute position.
+    #[inline]
+    pub fn set_relative_position(&mut self, rel_pos: Matrix<N>) {
+        self.relative_position = rel_pos
+    }
+
+    /// This sensor's absolute position.
+    #[inline]
+    pub fn position(&self) -> Matrix<N> {
+        match self.parent {
+            Some(ref rb) => *rb.borrow().position() * self.relative_position,
+            None         => self.relative_position.clone()
+        }
+    }
+
+    /// Sets the sensor absolute position.
+    ///
+    /// If `self.parent()` is not `None`, then this automatically computes the relevant relative
+    /// position and updates it.
+    #[inline]
+    pub fn set_position(&mut self, abs_pos: Matrix<N>) {
+        match self.parent {
+            Some(ref rb) => {
+                self.relative_position = na::inv(rb.borrow().position()).unwrap() * abs_pos
+            }
+            None => self.relative_position = abs_pos
+        }
+    }
+
+    /// This sensor position's translational component.
+    /// 
+    #[inline]
+    pub fn center(&self) -> Point<N> {
+        match self.parent {
+            Some(ref rb) => *rb.borrow().position() * na::translation(&self.relative_position).to_pnt(),
+            None         => na::translation(&self.relative_position).to_pnt()
+        }
+    }
+
+    /// The collision margin of this sensor's shape.
+    ///
+    /// This is set to zero by default.
+    pub fn margin(&self) -> N {
+        self.margin
+    }
+
+    /// Whether or not proximity detection between this sensor and its parent is enabled.
+    #[inline]
+    pub fn proximity_with_parent_enabled(&self) -> bool {
+        self.parent_prox
+    }
+
+    /// Enables proximity detection between this sensor and its parent if it has one.
+    #[inline]
+    pub fn enable_proximity_with_parent(&mut self) {
+        self.parent_prox = true;
+    }
+
+    /// Disables proximity detection between this sensor and its parent if it has one.
+    #[inline]
+    pub fn disable_proximity_with_parent(&mut self) {
+        self.parent_prox = false;
+    }
+
+    /// The rigid body to which this sensor is kinematically attached.
+    ///
+    /// Returns `None` if this sensor is directly attached to the scene.
+    #[inline]
+    pub fn parent(&self) -> Option<&RigidBodyHandle<N>> {
+        self.parent.as_ref()
+    }
+
+    /// A reference of this sensor's shared shape.
+    #[inline]
+    pub fn shape(&self) -> &CollisionShapeHandle<Point<N>, Matrix<N>> {
+        &self.shape
+    }
+
+    /// A reference of this sensor's shape.
+    #[inline]
+    pub fn shape_ref(&self) -> &(Repr<Point<N>, Matrix<N>>) {
+        &**self.shape
+    }
+
+    /// This sensor's collision groups.
+    #[inline]
+    pub fn collision_groups(&self) -> &SensorCollisionGroups {
+        &self.collision_groups
+    }
+}

--- a/src/object/sensor_collision_groups.rs
+++ b/src/object/sensor_collision_groups.rs
@@ -4,7 +4,7 @@ use object::{STATIC_GROUP_ID, SENSOR_GROUP_ID};
 /// Groups of collision used to filter which object collide with which other one.
 /// nphysics use a specific group for its own purposes (i.e. the group of static objects).
 /// The `group 29` is reserved and you cannot use it.
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, Copy)]
 pub struct SensorCollisionGroups {
     collision_groups: CollisionGroups
 }

--- a/src/object/sensor_collision_groups.rs
+++ b/src/object/sensor_collision_groups.rs
@@ -1,0 +1,45 @@
+use ncollide::world::CollisionGroups;
+use object::{STATIC_GROUP_ID, SENSOR_GROUP_ID};
+
+/// Groups of collision used to filter which object collide with which other one.
+/// nphysics use a specific group for its own purposes (i.e. the group of static objects).
+/// The `group 29` is reserved and you cannot use it.
+#[derive(Clone, Debug)]
+pub struct SensorCollisionGroups {
+    collision_groups: CollisionGroups
+}
+
+impl SensorCollisionGroups {
+    /// Creates a new `SensorCollisionGroups` that enables collisions with every user-defined
+    /// groups. Static objects and sensors are blacklisted by default and self-collision is disabled.
+    #[inline]
+    pub fn new() -> SensorCollisionGroups {
+        // All memberships + all whitelists activated.
+        let mut groups = CollisionGroups::new();
+
+        groups.modify_membership(STATIC_GROUP_ID, false);
+        groups.modify_membership(SENSOR_GROUP_ID, true);
+        groups.modify_whitelist(STATIC_GROUP_ID,  false);
+        groups.modify_whitelist(SENSOR_GROUP_ID,  false);
+
+        groups.modify_blacklist(STATIC_GROUP_ID, true);
+        groups.modify_blacklist(SENSOR_GROUP_ID, true);
+
+        SensorCollisionGroups{
+            collision_groups: groups
+        }
+    }
+
+
+    /*
+     * For compatibility with the implementation macro.
+     */
+    fn configure_reserved_flags(&self, _: bool) {
+    }
+
+    fn is_dynamic(&self) -> bool {
+        true
+    }
+}
+
+collision_groups_wrapper_impl!(SensorCollisionGroups);

--- a/src/object/world_object.rs
+++ b/src/object/world_object.rs
@@ -1,0 +1,201 @@
+use std::cell::{RefCell, Ref, RefMut};
+use ncollide::math::Scalar;
+use ncollide::inspection::Repr;
+use object::{RigidBody, Sensor, RigidBodyHandle, SensorHandle};
+use math::{Matrix, Point};
+
+/// An object that has been added to a World.
+#[derive(Clone)]
+pub enum WorldObject<N: Scalar> {
+    /// A rigid body handle.
+    RigidBody(RigidBodyHandle<N>),
+    /// A sensor handle.
+    Sensor(SensorHandle<N>)
+}
+
+/// Reference to a world object.
+pub enum WorldObjectBorrowed<'a, N: Scalar> {
+    /// A borrowed rigid body handle.
+    RigidBody(Ref<'a, RigidBody<N>>),
+    /// A borrowed sensor handle.
+    Sensor(Ref<'a, Sensor<N>>)
+}
+
+/// Mutable reference to a world object.
+pub enum WorldObjectBorrowedMut<'a, N: Scalar> {
+    /// A mutably borrowed rigid body handle.
+    RigidBody(RefMut<'a, RigidBody<N>>),
+    /// A mutably borrowed sensor handle.
+    Sensor(RefMut<'a, Sensor<N>>)
+}
+
+impl<N: Scalar> WorldObject<N> {
+    /// The unique identifier a rigid body would have if it was wrapped on a `WorldObject`.
+    ///
+    /// This identifier remains unique and will not change as long as `rb` is kept alive in memory.
+    #[inline]
+    pub fn rigid_body_uid(rb: &RigidBodyHandle<N>) -> usize {
+        &**rb as *const RefCell<RigidBody<N>> as usize
+    }
+
+    /// The unique identifier a sensor would have if it was wrapped on a `WorldObject`.
+    ///
+    /// This identifier remains unique and will not change as long as `s` is kept alive in memory.
+    #[inline]
+    pub fn sensor_uid(s: &SensorHandle<N>) -> usize {
+        &**s  as *const RefCell<Sensor<N>> as usize
+    }
+
+    /// Whether or not this is a rigid body.
+    #[inline]
+    pub fn is_rigid_body(&self) -> bool {
+        match *self {
+            WorldObject::RigidBody(_) => true,
+            _                         => false
+        }
+    }
+
+    /// Whether or not this is a sensor.
+    #[inline]
+    pub fn is_sensor(&self) -> bool {
+        match *self {
+            WorldObject::Sensor(_) => true,
+            _                      => false
+        }
+    }
+
+    /// Unwraps this object as a sensor or fails.
+    #[inline]
+    pub fn unwrap_sensor(self) -> SensorHandle<N> {
+        match self {
+            WorldObject::Sensor(s) => s,
+            _                      => panic!("This world object is not a sensor.")
+        }
+    }
+
+    /// Unwraps this object as a rigid body or fails.
+    #[inline]
+    pub fn unwrap_rigid_body(self) -> RigidBodyHandle<N> {
+        match self {
+            WorldObject::RigidBody(rb) => rb.clone(),
+            _                          => panic!("This world object is not a rigid body.")
+        }
+    }
+
+    /// Returns a unique id for this world object.
+    #[inline]
+    pub fn uid(&self) -> usize {
+        match *self {
+            WorldObject::RigidBody(ref rb) => WorldObject::rigid_body_uid(rb),
+            WorldObject::Sensor(ref s)     => WorldObject::sensor_uid(s)
+        }
+    }
+
+    /// Borrows this world object.
+    #[inline]
+    pub fn borrow(&self) -> WorldObjectBorrowed<N> {
+        match *self {
+            WorldObject::RigidBody(ref rb) => WorldObjectBorrowed::RigidBody(rb.borrow()),
+            WorldObject::Sensor(ref s)     => WorldObjectBorrowed::Sensor(s.borrow())
+        }
+    }
+
+    /// Borrows this world object as a sensor.
+    #[inline]
+    pub fn borrow_sensor(&self) -> Ref<Sensor<N>> {
+        match *self {
+            WorldObject::Sensor(ref s) => s.borrow(),
+            _                          => panic!("This world object is not a sensor.")
+        }
+    }
+
+    /// Borrows this world object as a rigid body.
+    #[inline]
+    pub fn borrow_rigid_body(&self) -> Ref<RigidBody<N>> {
+        match *self {
+            WorldObject::RigidBody(ref rb) => rb.borrow(),
+            _                              => panic!("This world object is not a rigid body.")
+        }
+    }
+
+    /// Mutably borrows this world object.
+    #[inline]
+    pub fn borrow_mut(&mut self) -> WorldObjectBorrowedMut<N> {
+        match *self {
+            WorldObject::RigidBody(ref mut rb) => WorldObjectBorrowedMut::RigidBody(rb.borrow_mut()),
+            WorldObject::Sensor(ref mut s)     => WorldObjectBorrowedMut::Sensor(s.borrow_mut())
+        }
+    }
+
+    /// Mutably borrows this world object as a sensor.
+    #[inline]
+    pub fn borrow_mut_sensor(&mut self) -> RefMut<Sensor<N>> {
+        match *self {
+            WorldObject::Sensor(ref mut s) => s.borrow_mut(),
+            _                              => panic!("This world object is not a sensor.")
+        }
+    }
+
+    /// Mutably borrows this world object as a rigid body.
+    #[inline]
+    pub fn borrow_mut_rigid_body(&mut self) -> RefMut<RigidBody<N>> {
+        match *self {
+            WorldObject::RigidBody(ref mut rb) => rb.borrow_mut(),
+            _                                  => panic!("This world object is not a rigid body.")
+        }
+    }
+}
+
+macro_rules! impl_getters(
+    ($t: ident) => (
+        impl<'a, N: Scalar> $t<'a, N> {
+            /// This object's position.
+            #[inline]
+            pub fn position(&self) -> Matrix<N> {
+                match *self {
+                    $t::RigidBody(ref rb) => rb.position().clone(),
+                    $t::Sensor(ref s)     => s.position()
+                }
+            }
+
+            /// A reference to this object geometrical shape.
+            #[inline]
+            pub fn shape_ref(&self) -> &(Repr<Point<N>, Matrix<N>>) {
+                match *self {
+                    $t::RigidBody(ref rb) => rb.shape_ref(),
+                    $t::Sensor(ref s)     => s.shape_ref()
+                }
+            }
+
+            /// This object margin.
+            #[inline]
+            pub fn margin(&self) -> N {
+                match *self {
+                    $t::RigidBody(ref rb) => rb.margin(),
+                    $t::Sensor(ref s)     => s.margin()
+                }
+            }
+
+            /// Whether or not this is a rigid body.
+            #[inline]
+            pub fn is_rigid_body(&self) -> bool {
+                match *self {
+                    $t::RigidBody(_) => true,
+                    _                => false
+                }
+            }
+
+            /// Whether or not this is a sensor.
+            #[inline]
+            pub fn is_sensor(&self) -> bool {
+                match *self {
+                    $t::Sensor(_) => true,
+                    _             => false
+                }
+            }
+        }
+    )
+);
+
+impl_getters!(WorldObjectBorrowed);
+impl_getters!(WorldObjectBorrowedMut);

--- a/src/object/world_object.rs
+++ b/src/object/world_object.rs
@@ -1,6 +1,6 @@
 use std::cell::{RefCell, Ref, RefMut};
 use ncollide::math::Scalar;
-use ncollide::inspection::Repr;
+use ncollide::shape::ShapeHandle;
 use object::{RigidBody, Sensor, RigidBodyHandle, SensorHandle};
 use math::{Matrix, Point};
 
@@ -160,10 +160,10 @@ macro_rules! impl_getters(
 
             /// A reference to this object geometrical shape.
             #[inline]
-            pub fn shape_ref(&self) -> &(Repr<Point<N>, Matrix<N>>) {
+            pub fn shape(&self) -> &ShapeHandle<Point<N>, Matrix<N>> {
                 match *self {
-                    $t::RigidBody(ref rb) => rb.shape_ref(),
-                    $t::Sensor(ref s)     => s.shape_ref()
+                    $t::RigidBody(ref rb) => rb.shape(),
+                    $t::Sensor(ref s)     => s.shape()
                 }
             }
 

--- a/src/resolution/constraint/accumulated_impulse_solver.rs
+++ b/src/resolution/constraint/accumulated_impulse_solver.rs
@@ -45,7 +45,7 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
             restitution_constraints: Vec::new(),
             friction_constraints:    Vec::new(),
             mj_lambda:               Vec::new(),
-            cache:                   ImpulseCache::new(step, na::dim::<Vector<N>>()),
+            cache:                   ImpulseCache::new(step, na::dimension::<Vector<N>>()),
 
             correction: CorrectionParameters {
                 corr_mode:  correction_mode,
@@ -94,17 +94,17 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
                 constraints: &[Constraint<N>],
                 joints:      &[usize],
                 bodies:      &[Rc<RefCell<RigidBody<N>>>]) {
-        let num_friction_equations    = (na::dim::<Vector<N>>() - 1) * self.cache.len();
+        let num_friction_equations    = (na::dimension::<Vector<N>>() - 1) * self.cache.len();
         let num_restitution_equations = self.cache.len();
         let mut num_joint_equations = 0;
 
         for i in joints.iter() {
             match constraints[*i] {
                 Constraint::BallInSocket(_) => {
-                    num_joint_equations = num_joint_equations + na::dim::<Vector<N>>()
+                    num_joint_equations = num_joint_equations + na::dimension::<Vector<N>>()
                 },
                 Constraint::Fixed(_) => {
-                    num_joint_equations = num_joint_equations + na::dim::<Vector<N>>() + na::dim::<Orientation<N>>()
+                    num_joint_equations = num_joint_equations + na::dimension::<Vector<N>>() + na::dimension::<Orientation<N>>()
                 },
                 Constraint::RBRB(_, _, _) => { }
             }
@@ -131,7 +131,7 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
                 _ => { }
             }
 
-            friction_offset = friction_offset + na::dim::<Vector<N>>() - 1;
+            friction_offset = friction_offset + na::dimension::<Vector<N>>() - 1;
         }
 
         let mut joint_offset = num_restitution_equations;
@@ -146,7 +146,7 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
                         &self.correction
                     );
 
-                    joint_offset = joint_offset + na::dim::<Vector<N>>();
+                    joint_offset = joint_offset + na::dimension::<Vector<N>>();
                 },
                 Constraint::Fixed(ref f) => {
                     fixed_equation::fill_second_order_equation(
@@ -156,7 +156,7 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
                         &self.correction
                     );
 
-                    joint_offset = joint_offset + na::dim::<Vector<N>>() + na::dim::<Orientation<N>>();
+                    joint_offset = joint_offset + na::dimension::<Vector<N>>() + na::dimension::<Orientation<N>>();
                 },
                 Constraint::RBRB(_, _, _) => { }
             }
@@ -191,15 +191,15 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
             let imps = self.cache.push_impulsions();
             imps[0]  = dv.impulse * na::cast::<f64, N>(0.85f64);
 
-            for j in 0usize .. na::dim::<Vector<N>>() - 1 {
-                let fc = &self.friction_constraints[i * (na::dim::<Vector<N>>() - 1) + j];
+            for j in 0usize .. na::dimension::<Vector<N>>() - 1 {
+                let fc = &self.friction_constraints[i * (na::dimension::<Vector<N>>() - 1) + j];
                 imps[1 + j] = fc.impulse * na::cast::<f64, N>(0.85f64);
             }
         }
 
         let offset = self.cache.reserved_impulse_offset();
         for (i, (_, kv)) in self.cache.hash_mut().iter_mut().enumerate() {
-            *kv = (kv.0, offset + i * na::dim::<Vector<N>>());
+            *kv = (kv.0, offset + i * na::dimension::<Vector<N>>());
         }
 
         /*
@@ -249,7 +249,7 @@ impl<N: Scalar> AccumulatedImpulseSolver<N> {
                 let center = &rb.center_of_mass().clone();
 
                 let mut delta: Matrix<N> = na::one();
-                delta.append_rotation_wrt_point_mut(&rotation, center.as_vec());
+                delta.append_rotation_wrt_point_mut(&rotation, center.as_vector());
                 delta.append_translation_mut(&translation);
 
                 rb.append_transformation(&delta);

--- a/src/resolution/constraint/ball_in_socket_equation.rs
+++ b/src/resolution/constraint/ball_in_socket_equation.rs
@@ -35,7 +35,7 @@ pub fn cancel_relative_linear_motion<N: Scalar, P>(
     let rot_axis1  = na::cross_matrix(&(*global1 - anchor1.center_of_mass()));
     let rot_axis2  = na::cross_matrix(&(*global2 - anchor2.center_of_mass()));
 
-    for i in 0usize .. na::dim::<Vector<N>>() {
+    for i in 0usize .. na::dimension::<Vector<N>>() {
         let mut lin_axis: Vector<N> = na::zero();
         let constraint = &mut constraints[i];
 
@@ -51,7 +51,7 @@ pub fn cancel_relative_linear_motion<N: Scalar, P>(
         // let rot_axis1 = -rot_axis1.col(i);
         // let rot_axis2 = rot_axis2.col(i);
         let (rot_axis1, rot_axis2) =
-            if na::dim::<Vector<N>>() == 2 {
+            if na::dimension::<Vector<N>>() == 2 {
                 (-rot_axis1.row(i), rot_axis2.row(i))
             }
             else { // == 3

--- a/src/resolution/constraint/fixed_equation.rs
+++ b/src/resolution/constraint/fixed_equation.rs
@@ -16,8 +16,8 @@ pub fn fill_second_order_equation<N: Scalar>(dt:          N,
 
     ball_in_socket_equation::cancel_relative_linear_motion(
         dt.clone(),
-        &ref1.translate(&na::orig()),
-        &ref2.translate(&na::orig()),
+        &ref1.translate(&na::origin()),
+        &ref2.translate(&na::origin()),
         joint.anchor1(),
         joint.anchor2(),
         constraints,
@@ -29,7 +29,7 @@ pub fn fill_second_order_equation<N: Scalar>(dt:          N,
         &ref2,
         joint.anchor1(),
         joint.anchor2(),
-        &mut constraints[na::dim::<Vector<N>>() ..],
+        &mut constraints[na::dimension::<Vector<N>>() ..],
         correction);
 }
 
@@ -40,7 +40,7 @@ pub fn cancel_relative_angular_motion<N: Scalar, P>(dt:          N,
                                                     anchor2:     &Anchor<N, P>,
                                                     constraints: &mut [VelocityConstraint<N>],
                                                     correction:  &CorrectionParameters<N>) {
-    let delta     = na::inv(ref2).expect("ref2 must be inversible.") * *ref1;
+    let delta     = na::inverse(ref2).expect("ref2 must be inversible.") * *ref1;
     let delta_rot = delta.rotation();
 
     let mut i = 0;

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ mod test {
     #[cfg(feature = "dim2")]
     use na;
     #[cfg(feature = "dim2")]
-    use na::{Vec1, Vec2, Iso2};
+    use na::{Vec1, Vector2, Isometry2};
     #[cfg(feature = "dim2")]
     use ncollide::shape::Cuboid;
     #[cfg(feature = "dim2")]
@@ -19,18 +19,18 @@ mod test {
         let mut world = World::new();
 
         // rigidbody with side length 2, area 4 and mass 4
-        let geom   = Cuboid::new(Vec2::new(1.0, 1.0));
+        let geom   = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.6);
         let rb_handle = world.add_body(rb.clone());
 
         // ensure it's at the origin
-        let expected = &Iso2::new(na::zero(), na::zero());
+        let expected = &Isometry2::new(na::zero(), na::zero());
         assert!(na::approx_eq(rb_handle.borrow().position(), expected),
                 format!("Initial position should be at zero. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
         // set gravity
-        let gravity = Vec2::new(0.0, 20.0);
+        let gravity = Vector2::new(0.0, 20.0);
         world.set_gravity(gravity);
 
         // remove body and trigger a rust panic
@@ -39,7 +39,7 @@ mod test {
 
         // add another body in same position triggers a panic in ncollide
         // 	let mut rb3 = rb.clone();
-        // 	rb3.append_translation(&Vec2::new(0.0, 0.0));
+        // 	rb3.append_translation(&Vector2::new(0.0, 0.0));
         // 	let rb_handle3 = world.add_body(rb3);
 
         // simulate a huge time step
@@ -48,7 +48,7 @@ mod test {
         // terminal velocity for the entire time duration. Therefore it moves farther
         // than it actually should. Use smaller time intervals to approximate more
         // realistic values (see below).
-        let expected = &Iso2::new(Vec2::new(0.0, 20.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 20.0), na::zero());
         world.step(1.0);
         assert!(na::approx_eq(rb_handle.borrow().position(), expected),
                 format!("Gravity did not pull object correctly (large time step). Actual: {:?}, Expected: {:?}",
@@ -56,11 +56,11 @@ mod test {
 
 
         // reset the body
-        rb_handle.borrow_mut().set_lin_vel(Vec2::new(0.0, 0.0));
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_lin_vel(Vector2::new(0.0, 0.0));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
 
         // simulate small time steps
-        let expected = &Iso2::new(Vec2::new(0.0, 10.01), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 10.01), na::zero());
         for _ in 0 .. 1000 {
             world.step(0.001);
         }
@@ -70,11 +70,11 @@ mod test {
 
 
         // reset the body
-        rb_handle.borrow_mut().set_lin_vel(Vec2::new(0.0, 20.0));
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_lin_vel(Vector2::new(0.0, 20.0));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
 
         // Switch off gravity globally
-        let expected = &Iso2::new(Vec2::new(0.0, 20.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 20.0), na::zero());
         world.set_gravity(na::zero());
         for _ in 0 .. 1000 {
             world.step(0.001);
@@ -85,8 +85,8 @@ mod test {
 
 
         // reset the body
-        rb_handle.borrow_mut().set_lin_vel(Vec2::new(0.0, 0.0));
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_lin_vel(Vector2::new(0.0, 0.0));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
 
         // Wait until body deactivates
         for _ in 0 .. 1000 {
@@ -100,13 +100,13 @@ mod test {
                 format!("Body should be active by now, but is {:?}", rb_handle.borrow().activation_state()));
 
         // Changing gravity has to work
-        let expected = &Iso2::new(Vec2::new(0.0, 10.0), na::zero());
-        world.set_gravity(Vec2::new(0.0, 20.0));
+        let expected = &Isometry2::new(Vector2::new(0.0, 10.0), na::zero());
+        world.set_gravity(Vector2::new(0.0, 20.0));
         for _ in 0 .. 1000 {
             world.step(0.001);
         }
 
-        world.set_gravity(Vec2::new(0.0, -20.0));
+        world.set_gravity(Vector2::new(0.0, -20.0));
         for _ in 0 .. 2000 {
             world.step(0.001);
         }
@@ -125,22 +125,22 @@ mod test {
         let mut world = World::new();
 
         // rigidbody with side length 2, area 4 and mass 4
-        let geom   = Cuboid::new(Vec2::new(1.0, 1.0));
+        let geom   = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom.clone(), 1.0, 0.3, 0.6);
         let rb_handle = world.add_body(rb.clone());
 
         // add another body with double the density
         let mut rb2 = RigidBody::new_dynamic(geom.clone(), 2.0, 0.3, 0.6);
-        rb2.append_translation(&Vec2::new(5.0, 0.0));
+        rb2.append_translation(&Vector2::new(5.0, 0.0));
         let rb_handle2 = world.add_body(rb2);
 
         // switch off gravity
-        world.set_gravity(Vec2::new(0.0, 0.0));
+        world.set_gravity(Vector2::new(0.0, 0.0));
 
         // Force has to work for different masses
         // apply force
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(0.0, 10.0));
-        rb_handle2.borrow_mut().append_lin_force(Vec2::new(0.0, 10.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
+        rb_handle2.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
         rb_handle.borrow_mut().set_deactivation_threshold( None );
         rb_handle2.borrow_mut().set_deactivation_threshold( None );
 
@@ -150,21 +150,21 @@ mod test {
         }
         // mass of 4 (kg), force of 10 (N) => acc = force/mass = 2.5 (m/s^2)
         // distance after 2 secs: x = 1/2 * acc * t^2 = 5 (m)
-        let expected = &Iso2::new(Vec2::new(0.0, 5.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 5.0), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Force did not properly pull first body. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // mass of 8 (kg), force of 10 (N)=> acc = force/mass = 1.25 (m/s^2)
         // distance after 2 secs: x = 1/2 * acc * t^2 = 2.5 (m)
-        let expected = &Iso2::new(Vec2::new(5.0, 2.5), na::zero());
+        let expected = &Isometry2::new(Vector2::new(5.0, 2.5), na::zero());
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Force did not properly pull second body. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_lin_vel(Vec2::new(0.0, 0.0));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_lin_vel(Vector2::new(0.0, 0.0));
         rb_handle2.borrow_mut().deactivate();
 
         // clearing forces has to work
@@ -173,20 +173,20 @@ mod test {
         for _ in 0 .. 1000 {
             world.step(0.001);
         }
-        let expected = &Iso2::new(Vec2::new(0.0, 0.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 0.0), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Force should have been cleared. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
 
         // adding forces has to work
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(0.0, 5.0));
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(-10.0, 5.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 5.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(-10.0, 5.0));
         // simulate
         for _ in 0 .. 2000 {
             world.step(0.001);
         }
-        let expected = &Iso2::new(Vec2::new(-5.0, 5.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(-5.0, 5.0), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Forces did not properly add up. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -194,11 +194,11 @@ mod test {
 
         // angular force has to work correctly for different inertias and types
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_lin_vel(Vec2::new(0.0, 0.0));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_lin_vel(Vector2::new(0.0, 0.0));
         rb_handle.borrow_mut().clear_forces();
-        rb_handle2.borrow_mut().set_transformation(Iso2::new(Vec2::new(5.0, 0.0), na::zero()));
-        rb_handle2.borrow_mut().set_lin_vel(Vec2::new(0.0, 0.0));
+        rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
+        rb_handle2.borrow_mut().set_lin_vel(Vector2::new(0.0, 0.0));
         rb_handle2.borrow_mut().activate(1.0);
         rb_handle2.borrow_mut().clear_forces();
 
@@ -213,22 +213,22 @@ mod test {
         // expected angle
         // force of force of 10 (N), inertia of 2.67 => acc = force/inertia = 3.75 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = 1.875
-        let expected = &Iso2::new(na::zero(), Vec1::new(1.875));
+        let expected = &Isometry2::new(na::zero(), Vec1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Rotation did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected angle
         // force of force of 10 (N), inertia of 5.33 => acc = force/inertia = 1.875 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = 0.9375
-        let expected = &Iso2::new(Vec2::new(5.0, 0.0), Vec1::new(0.9375));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(0.9375));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Rotation2 did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
         // clear angular forces
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
-        rb_handle2.borrow_mut().set_transformation(Iso2::new(Vec2::new(5.0, 0.0), na::zero()));
+        rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
         rb_handle2.borrow_mut().set_ang_vel(Vec1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
         rb_handle2.borrow_mut().clear_angular_force();
@@ -238,19 +238,19 @@ mod test {
             world.step(0.001);
         }
         // expected angle
-        let expected = &Iso2::new(na::zero(), Vec1::new(0.0));
+        let expected = &Isometry2::new(na::zero(), Vec1::new(0.0));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Rotation did not properly stop. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected angle
-        let expected = &Iso2::new(Vec2::new(5.0, 0.0), Vec1::new(0.0));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(0.0));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Rotation2 did not properly stop. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
         rb_handle2.borrow_mut().deactivate();
@@ -266,19 +266,19 @@ mod test {
         // expected angle
         // resulting force of force of -10 (N), inertia of 2.67 => acc = force/inertia = -3.75 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = -1.875
-        let expected = &Iso2::new(na::zero(), Vec1::new(-1.875));
+        let expected = &Isometry2::new(na::zero(), Vec1::new(-1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Combined forces rotation did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
 
         // set and clear both linear and angular forces
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(0.0, 10.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
         rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
         rb_handle.borrow_mut().clear_forces();
 
@@ -287,18 +287,18 @@ mod test {
             world.step(0.001);
         }
         // expected result, body remains in the origin as all forces got cleared
-        let expected = &Iso2::new(na::zero(), na::zero());
+        let expected = &Isometry2::new(na::zero(), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Cleared forces shouldn't work anymore. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
 
         // only clear angular force
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(0.0, 10.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
         rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
         rb_handle.borrow_mut().clear_angular_force();
 
@@ -307,20 +307,20 @@ mod test {
             world.step(0.001);
         }
         // expected result, body moves but doesn't rotate
-        let expected = &Iso2::new(Vec2::new(0.0, 5.0), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 5.0), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Only linear movement is expected. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_lin_vel(na::zero());
         rb_handle.borrow_mut().set_ang_vel(na::zero());
         rb_handle.borrow_mut().clear_forces();
 
         // only clear linear force
-        rb_handle.borrow_mut().append_lin_force(Vec2::new(0.0, 10.0));
+        rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
         rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
         rb_handle.borrow_mut().clear_linear_force();
 
@@ -329,27 +329,27 @@ mod test {
             world.step(0.001);
         }
         // expected result, body rotates but doesn't move
-        let expected = &Iso2::new(na::zero(), Vec1::new(1.875));
+        let expected = &Isometry2::new(na::zero(), Vec1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_lin_vel(na::zero());
         rb_handle.borrow_mut().set_ang_vel(na::zero());
         rb_handle.borrow_mut().clear_forces();
         rb_handle.borrow_mut().activate(1.0);
-        rb_handle2.borrow_mut().set_transformation(Iso2::new(Vec2::new(5.0, 0.0), na::zero()));
+        rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
         rb_handle2.borrow_mut().set_lin_vel(na::zero());
         rb_handle2.borrow_mut().set_ang_vel(na::zero());
         rb_handle2.borrow_mut().clear_forces();
         rb_handle2.borrow_mut().activate(1.0);
 
         // apply force on point
-        rb_handle.borrow_mut().append_force_wrt_point(Vec2::new(0.0, 10.0), Vec2::new(1.0, 1.0));
-        rb_handle2.borrow_mut().append_force_wrt_point(Vec2::new(0.0, 10.0), Vec2::new(1.0, 1.0));
+        rb_handle.borrow_mut().append_force_wrt_point(Vector2::new(0.0, 10.0), Vector2::new(1.0, 1.0));
+        rb_handle2.borrow_mut().append_force_wrt_point(Vector2::new(0.0, 10.0), Vector2::new(1.0, 1.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -358,14 +358,14 @@ mod test {
         // expected result
         // linear displacement 1.25
         // angular rotation: -1.875
-        let expected = &Iso2::new(Vec2::new(0.0, 1.25), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(0.0, 1.25), Vec1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected result
         // linear displacement 1.25
         // angular rotation: -1.875
-        let expected = &Iso2::new(Vec2::new(5.0, 0.625), Vec1::new(0.9375));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.625), Vec1::new(0.9375));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
@@ -379,21 +379,21 @@ mod test {
         let mut world = World::new();
 
         // rigidbody with side length 2, area 4 and mass 4
-        let geom = Cuboid::new(Vec2::new(1.0, 1.0));
+        let geom = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom.clone(), 1.0, 0.3, 0.6);
         let rb_handle = world.add_body(rb.clone());
 
         // add another body with double the density
         let mut rb2 = RigidBody::new_dynamic(geom.clone(), 2.0, 0.3, 0.6);
-        rb2.append_translation(&Vec2::new(5.0, 0.0));
+        rb2.append_translation(&Vector2::new(5.0, 0.0));
         let rb_handle2 = world.add_body(rb2);
 
         // switch off gravity
-        world.set_gravity(Vec2::new(0.0, 0.0));
+        world.set_gravity(Vector2::new(0.0, 0.0));
 
         // impulses have to work for different masses
-        rb_handle.borrow_mut().apply_central_impulse(Vec2::new(0.0, 10.0));
-        rb_handle2.borrow_mut().apply_central_impulse(Vec2::new(0.0, 10.0));
+        rb_handle.borrow_mut().apply_central_impulse(Vector2::new(0.0, 10.0));
+        rb_handle2.borrow_mut().apply_central_impulse(Vector2::new(0.0, 10.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -403,7 +403,7 @@ mod test {
         // impulse of 10 N*s on body with mass 4 (kg) results in
         // velocity = impulse/mass = 10 N*s / 4 kg = 2.5 m/s
         // distance = velocity * time = 2.5 m/s * 1 s = 2.5 m
-        let expected = &Iso2::new(Vec2::new(0.0, 2.5), na::zero());
+        let expected = &Isometry2::new(Vector2::new(0.0, 2.5), na::zero());
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Different impulse result is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -411,19 +411,19 @@ mod test {
         // impulse of 10 N*s on body with mass 8 (kg) results in
         // velocity = impulse/mass = 10 N*s / 8 kg = 1.25 m/s
         // distance = velocity * time = 1.25 m/s * 1 s = 1.25 m
-        let expected = &Iso2::new(Vec2::new(5.0, 1.25), na::zero());
+        let expected = &Isometry2::new(Vector2::new(5.0, 1.25), na::zero());
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Different impulse result is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_lin_vel(na::zero());
         rb_handle.borrow_mut().set_ang_vel(na::zero());
         rb_handle.borrow_mut().clear_forces();
         rb_handle.borrow_mut().activate(1.0);
-        rb_handle2.borrow_mut().set_transformation(Iso2::new(Vec2::new(5.0, 0.0), na::zero()));
+        rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
         rb_handle2.borrow_mut().set_lin_vel(na::zero());
         rb_handle2.borrow_mut().set_ang_vel(na::zero());
         rb_handle2.borrow_mut().clear_forces();
@@ -442,7 +442,7 @@ mod test {
         // torque of 10 N*m*s on body with inertia of 2.67 kg*m^2 results in
         // rotation speed of rvel = 10 N*m*s / 2.67 kg*m^2 = 3.75 1/s
         // angle after 1s: 3.75
-        let expected = &Iso2::new(Vec2::new(0.0, 0.0), Vec1::new(3.75));
+        let expected = &Isometry2::new(Vector2::new(0.0, 0.0), Vec1::new(3.75));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -450,27 +450,27 @@ mod test {
         // torque of 10 N*m*s on body with inertia of 5.33 kg*m^2 results in
         // rotation speed of rvel = 10 N*m*s / 5.33 kg*m^2 = 1.875 1/s
         // angle after 1s: 1.875
-        let expected = &Iso2::new(Vec2::new(5.0, 0.0), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
 
         // reset bodies
-        rb_handle.borrow_mut().set_transformation(Iso2::new(na::zero(), na::zero()));
+        rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
         rb_handle.borrow_mut().set_lin_vel(na::zero());
         rb_handle.borrow_mut().set_ang_vel(na::zero());
         rb_handle.borrow_mut().clear_forces();
         rb_handle.borrow_mut().activate(1.0);
-        rb_handle2.borrow_mut().set_transformation(Iso2::new(Vec2::new(5.0, 0.0), na::zero()));
+        rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
         rb_handle2.borrow_mut().set_lin_vel(na::zero());
         rb_handle2.borrow_mut().set_ang_vel(na::zero());
         rb_handle2.borrow_mut().clear_forces();
         rb_handle2.borrow_mut().activate(1.0);
 
         // nudge
-        rb_handle.borrow_mut().apply_impulse_wrt_point(Vec2::new(0.0, 10.0), Vec2::new(1.0, 1.0));
-        rb_handle2.borrow_mut().apply_impulse_wrt_point(Vec2::new(0.0, 10.0), Vec2::new(1.0, 1.0));
+        rb_handle.borrow_mut().apply_impulse_wrt_point(Vector2::new(0.0, 10.0), Vector2::new(1.0, 1.0));
+        rb_handle2.borrow_mut().apply_impulse_wrt_point(Vector2::new(0.0, 10.0), Vector2::new(1.0, 1.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -479,14 +479,14 @@ mod test {
 
         // expected values are the combination of the values in the two previous tests,
         // except with opposite rotation direction
-        let expected = &Iso2::new(Vec2::new(0.0, 2.5), Vec1::new(3.75));
+        let expected = &Isometry2::new(Vector2::new(0.0, 2.5), Vec1::new(3.75));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
         // expected values are the combination of the values in the two previous tests,
         // except with opposite rotation direction
-        let expected = &Iso2::new(Vec2::new(5.0, 1.25), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(5.0, 1.25), Vec1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -3,7 +3,7 @@ mod test {
     #[cfg(feature = "dim2")]
     use na;
     #[cfg(feature = "dim2")]
-    use na::{Vec1, Vector2, Isometry2};
+    use na::{Vector1, Vector2, Isometry2};
     #[cfg(feature = "dim2")]
     use ncollide::shape::Cuboid;
     #[cfg(feature = "dim2")]
@@ -21,7 +21,7 @@ mod test {
         // rigidbody with side length 2, area 4 and mass 4
         let geom   = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom, 1.0, 0.3, 0.6);
-        let rb_handle = world.add_body(rb.clone());
+        let rb_handle = world.add_rigid_body(rb.clone());
 
         // ensure it's at the origin
         let expected = &Isometry2::new(na::zero(), na::zero());
@@ -127,12 +127,12 @@ mod test {
         // rigidbody with side length 2, area 4 and mass 4
         let geom   = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom.clone(), 1.0, 0.3, 0.6);
-        let rb_handle = world.add_body(rb.clone());
+        let rb_handle = world.add_rigid_body(rb.clone());
 
         // add another body with double the density
         let mut rb2 = RigidBody::new_dynamic(geom.clone(), 2.0, 0.3, 0.6);
         rb2.append_translation(&Vector2::new(5.0, 0.0));
-        let rb_handle2 = world.add_body(rb2);
+        let rb_handle2 = world.add_rigid_body(rb2);
 
         // switch off gravity
         world.set_gravity(Vector2::new(0.0, 0.0));
@@ -141,8 +141,8 @@ mod test {
         // apply force
         rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
         rb_handle2.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
-        rb_handle.borrow_mut().set_deactivation_threshold( None );
-        rb_handle2.borrow_mut().set_deactivation_threshold( None );
+        rb_handle.borrow_mut().set_deactivation_threshold(None);
+        rb_handle2.borrow_mut().set_deactivation_threshold(None);
 
         // simulate
         for _ in 0 .. 2000 {
@@ -203,8 +203,8 @@ mod test {
         rb_handle2.borrow_mut().clear_forces();
 
         // add angular forces
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
-        rb_handle2.borrow_mut().append_ang_force(Vec1::new(10.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(10.0));
+        rb_handle2.borrow_mut().append_ang_force(Vector1::new(10.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -213,23 +213,23 @@ mod test {
         // expected angle
         // force of force of 10 (N), inertia of 2.67 => acc = force/inertia = 3.75 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = 1.875
-        let expected = &Isometry2::new(na::zero(), Vec1::new(1.875));
+        let expected = &Isometry2::new(na::zero(), Vector1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Rotation did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected angle
         // force of force of 10 (N), inertia of 5.33 => acc = force/inertia = 1.875 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = 0.9375
-        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(0.9375));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vector1::new(0.9375));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Rotation2 did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
 
         // clear angular forces
         rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
+        rb_handle.borrow_mut().set_ang_vel(Vector1::new(0.0));
         rb_handle2.borrow_mut().set_transformation(Isometry2::new(Vector2::new(5.0, 0.0), na::zero()));
-        rb_handle2.borrow_mut().set_ang_vel(Vec1::new(0.0));
+        rb_handle2.borrow_mut().set_ang_vel(Vector1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
         rb_handle2.borrow_mut().clear_angular_force();
 
@@ -238,12 +238,12 @@ mod test {
             world.step(0.001);
         }
         // expected angle
-        let expected = &Isometry2::new(na::zero(), Vec1::new(0.0));
+        let expected = &Isometry2::new(na::zero(), Vector1::new(0.0));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Rotation did not properly stop. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected angle
-        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(0.0));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vector1::new(0.0));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Rotation2 did not properly stop. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
@@ -251,13 +251,13 @@ mod test {
 
         // reset bodies
         rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
+        rb_handle.borrow_mut().set_ang_vel(Vector1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
         rb_handle2.borrow_mut().deactivate();
 
         // add angular forces
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(-20.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(10.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(-20.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -266,7 +266,7 @@ mod test {
         // expected angle
         // resulting force of force of -10 (N), inertia of 2.67 => acc = force/inertia = -3.75 rad/s^2
         // 1 sec acceleration => angle = 1/2 * acc * t^2 = -1.875
-        let expected = &Isometry2::new(na::zero(), Vec1::new(-1.875));
+        let expected = &Isometry2::new(na::zero(), Vector1::new(-1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Combined forces rotation did not properly work. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -274,12 +274,12 @@ mod test {
 
         // reset bodies
         rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
+        rb_handle.borrow_mut().set_ang_vel(Vector1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
 
         // set and clear both linear and angular forces
         rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(10.0));
         rb_handle.borrow_mut().clear_forces();
 
         // simulate
@@ -294,12 +294,12 @@ mod test {
 
         // reset bodies
         rb_handle.borrow_mut().set_transformation(Isometry2::new(na::zero(), na::zero()));
-        rb_handle.borrow_mut().set_ang_vel(Vec1::new(0.0));
+        rb_handle.borrow_mut().set_ang_vel(Vector1::new(0.0));
         rb_handle.borrow_mut().clear_angular_force();
 
         // only clear angular force
         rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(10.0));
         rb_handle.borrow_mut().clear_angular_force();
 
         // simulate
@@ -321,7 +321,7 @@ mod test {
 
         // only clear linear force
         rb_handle.borrow_mut().append_lin_force(Vector2::new(0.0, 10.0));
-        rb_handle.borrow_mut().append_ang_force(Vec1::new(10.0));
+        rb_handle.borrow_mut().append_ang_force(Vector1::new(10.0));
         rb_handle.borrow_mut().clear_linear_force();
 
         // simulate
@@ -329,7 +329,7 @@ mod test {
             world.step(0.001);
         }
         // expected result, body rotates but doesn't move
-        let expected = &Isometry2::new(na::zero(), Vec1::new(1.875));
+        let expected = &Isometry2::new(na::zero(), Vector1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -358,14 +358,14 @@ mod test {
         // expected result
         // linear displacement 1.25
         // angular rotation: -1.875
-        let expected = &Isometry2::new(Vector2::new(0.0, 1.25), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(0.0, 1.25), Vector1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
         // expected result
         // linear displacement 1.25
         // angular rotation: -1.875
-        let expected = &Isometry2::new(Vector2::new(5.0, 0.625), Vec1::new(0.9375));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.625), Vector1::new(0.9375));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Only rotation is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
@@ -381,12 +381,12 @@ mod test {
         // rigidbody with side length 2, area 4 and mass 4
         let geom = Cuboid::new(Vector2::new(1.0, 1.0));
         let rb = RigidBody::new_dynamic(geom.clone(), 1.0, 0.3, 0.6);
-        let rb_handle = world.add_body(rb.clone());
+        let rb_handle = world.add_rigid_body(rb.clone());
 
         // add another body with double the density
         let mut rb2 = RigidBody::new_dynamic(geom.clone(), 2.0, 0.3, 0.6);
         rb2.append_translation(&Vector2::new(5.0, 0.0));
-        let rb_handle2 = world.add_body(rb2);
+        let rb_handle2 = world.add_rigid_body(rb2);
 
         // switch off gravity
         world.set_gravity(Vector2::new(0.0, 0.0));
@@ -430,8 +430,8 @@ mod test {
         rb_handle2.borrow_mut().activate(1.0);
 
         // torques have to work for different inertias
-        rb_handle.borrow_mut().apply_angular_momentum(Vec1::new(10.0));
-        rb_handle2.borrow_mut().apply_angular_momentum(Vec1::new(10.0));
+        rb_handle.borrow_mut().apply_angular_momentum(Vector1::new(10.0));
+        rb_handle2.borrow_mut().apply_angular_momentum(Vector1::new(10.0));
 
         // simulate
         for _ in 0 .. 1000 {
@@ -442,7 +442,7 @@ mod test {
         // torque of 10 N*m*s on body with inertia of 2.67 kg*m^2 results in
         // rotation speed of rvel = 10 N*m*s / 2.67 kg*m^2 = 3.75 1/s
         // angle after 1s: 3.75
-        let expected = &Isometry2::new(Vector2::new(0.0, 0.0), Vec1::new(3.75));
+        let expected = &Isometry2::new(Vector2::new(0.0, 0.0), Vector1::new(3.75));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
@@ -450,7 +450,7 @@ mod test {
         // torque of 10 N*m*s on body with inertia of 5.33 kg*m^2 results in
         // rotation speed of rvel = 10 N*m*s / 5.33 kg*m^2 = 1.875 1/s
         // angle after 1s: 1.875
-        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(5.0, 0.0), Vector1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));
@@ -479,14 +479,14 @@ mod test {
 
         // expected values are the combination of the values in the two previous tests,
         // except with opposite rotation direction
-        let expected = &Isometry2::new(Vector2::new(0.0, 2.5), Vec1::new(3.75));
+        let expected = &Isometry2::new(Vector2::new(0.0, 2.5), Vector1::new(3.75));
         assert!(na::approx_eq_eps(rb_handle.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 1. Actual: {:?}, Expected: {:?}",
                         rb_handle.borrow().position(), expected));
 
         // expected values are the combination of the values in the two previous tests,
         // except with opposite rotation direction
-        let expected = &Isometry2::new(Vector2::new(5.0, 1.25), Vec1::new(1.875));
+        let expected = &Isometry2::new(Vector2::new(5.0, 1.25), Vector1::new(1.875));
         assert!(na::approx_eq_eps(rb_handle2.borrow().position(), expected, &0.01),
                 format!("Different torque result is expected on body 2. Actual: {:?}, Expected: {:?}",
                         rb_handle2.borrow().position(), expected));

--- a/src/volumetric/mod.rs
+++ b/src/volumetric/mod.rs
@@ -3,17 +3,20 @@
 #[doc(inline)]
 pub use volumetric::volumetric::{Volumetric, InertiaTensor};
 
-pub use volumetric::volumetric_ball::{ball_volume, ball_surface, ball_center_of_mass,
+pub use volumetric::volumetric_ball::{ball_volume, ball_area, ball_center_of_mass,
                                       ball_unit_angular_inertia};
-pub use volumetric::volumetric_cylinder::{cylinder_volume, cylinder_surface,
+pub use volumetric::volumetric_cylinder::{cylinder_volume, cylinder_area,
                                           cylinder_center_of_mass, cylinder_unit_angular_inertia};
-pub use volumetric::volumetric_cone::{cone_volume, cone_surface,
+pub use volumetric::volumetric_cone::{cone_volume, cone_area,
                                       cone_center_of_mass, cone_unit_angular_inertia};
-pub use volumetric::volumetric_cuboid::{cuboid_volume, cuboid_surface,
+pub use volumetric::volumetric_cuboid::{cuboid_volume, cuboid_area,
                                         cuboid_center_of_mass, cuboid_unit_angular_inertia};
-pub use volumetric::volumetric_convex::{convex_mesh_surface, convex_mesh_volume_and_center_of_mass,
-                                        convex_mesh_mass_properties, convex_hull_surface,
-                                        convex_hull_volume, convex_hull_center_of_mass,
+pub use volumetric::volumetric_convex::{convex_polyline_area, convex_mesh_area,
+                                        convex_polyline_area_and_center_of_mass,
+                                        convex_mesh_volume_and_center_of_mass,
+                                        convex_polyline_mass_properties,
+                                        convex_mesh_mass_properties,
+                                        convex_hull_area, convex_hull_volume, convex_hull_center_of_mass,
                                         convex_hull_unit_angular_inertia};
 
 #[doc(hidden)]

--- a/src/volumetric/volumetric.rs
+++ b/src/volumetric/volumetric.rs
@@ -21,8 +21,8 @@ pub trait InertiaTensor<N, P, AV, M> {
 
 /// Trait implemented by objects which have a mass, a center of mass, and an inertia tensor.
 pub trait Volumetric<N: Scalar, P, I: Mul<N, Output = I>> {
-    /// Computes the surface of this object.
-    fn surface(&self) -> N;
+    /// Computes the area of this object.
+    fn area(&self) -> N;
 
     /// Computes the volume of this object.
     fn volume(&self) -> N;

--- a/src/volumetric/volumetric.rs
+++ b/src/volumetric/volumetric.rs
@@ -2,7 +2,7 @@
 
 use std::ops::Mul;
 use na;
-use na::{Pnt2, Pnt3, Vec1, Vec3, Iso2, Iso3, Mat1, Mat3};
+use na::{Point2, Point3, Vector1, Vector3, Isometry2, Isometry3, Matrix1, Matrix3};
 use ncollide::math::Scalar;
 
 /// Trait implemented by inertia tensors.
@@ -54,44 +54,44 @@ pub trait Volumetric<N: Scalar, P, I: Mul<N, Output = I>> {
 
 }
 
-impl<N: Scalar> InertiaTensor<N, Pnt2<N>, Vec1<N>, Iso2<N>> for Mat1<N> {
+impl<N: Scalar> InertiaTensor<N, Point2<N>, Vector1<N>, Isometry2<N>> for Matrix1<N> {
     #[inline]
-    fn apply(&self, av: &Vec1<N>) -> Vec1<N> {
+    fn apply(&self, av: &Vector1<N>) -> Vector1<N> {
         *self * *av
     }
 
     #[inline]
-    fn to_world_space(&self, _: &Iso2<N>) -> Mat1<N> {
+    fn to_world_space(&self, _: &Isometry2<N>) -> Matrix1<N> {
         self.clone()
     }
 
     #[inline]
-    fn to_relative_wrt_point(&self, mass: N, pt: &Pnt2<N>) -> Mat1<N> {
-        *self + Mat1::new(mass * na::sqnorm(pt.as_vec()))
+    fn to_relative_wrt_point(&self, mass: N, pt: &Point2<N>) -> Matrix1<N> {
+        *self + Matrix1::new(mass * na::norm_squared(pt.as_vector()))
     }
 }
 
-impl<N: Scalar> InertiaTensor<N, Pnt3<N>, Vec3<N>, Iso3<N>> for Mat3<N> {
+impl<N: Scalar> InertiaTensor<N, Point3<N>, Vector3<N>, Isometry3<N>> for Matrix3<N> {
     #[inline]
-    fn apply(&self, av: &Vec3<N>) -> Vec3<N> {
+    fn apply(&self, av: &Vector3<N>) -> Vector3<N> {
         *self * *av
     }
 
     #[inline]
-    fn to_world_space(&self, t: &Iso3<N>) -> Mat3<N> {
-        let inv = na::inv(&t.rotation).unwrap();
-        *t.rotation.submat() * *self * *inv.submat()
+    fn to_world_space(&self, t: &Isometry3<N>) -> Matrix3<N> {
+        let inverse = na::inverse(&t.rotation).unwrap();
+        *t.rotation.submatrix() * *self * *inverse.submatrix()
     }
 
     #[inline]
-    fn to_relative_wrt_point(&self, mass: N, pt: &Pnt3<N>) -> Mat3<N> {
-        let diag  = na::sqnorm(pt.as_vec());
-        let diagm = Mat3::new(
+    fn to_relative_wrt_point(&self, mass: N, pt: &Point3<N>) -> Matrix3<N> {
+        let diag  = na::norm_squared(pt.as_vector());
+        let diagm = Matrix3::new(
             diag.clone(), na::zero(),   na::zero(),
             na::zero(),   diag.clone(), na::zero(),
             na::zero(),   na::zero(),   diag
         );
 
-        *self + (diagm - na::outer(pt.as_vec(), pt.as_vec())) * mass
+        *self + (diagm - na::outer(pt.as_vector(), pt.as_vector())) * mass
     }
 }

--- a/src/volumetric/volumetric_ball.rs
+++ b/src/volumetric/volumetric_ball.rs
@@ -1,6 +1,6 @@
 use std::ops::IndexMut;
 use num::{Float, Zero};
-use na::{Orig, BaseFloat, Pnt2, Pnt3, Mat1, Mat3};
+use na::{Origin, BaseFloat, Point2, Point3, Matrix1, Matrix3};
 use na;
 use ncollide::math::Scalar;
 use ncollide::shape::{Ball2, Ball3};
@@ -9,19 +9,19 @@ use volumetric::Volumetric;
 
 /// The volume of a ball.
 #[inline]
-pub fn ball_volume<N: Scalar>(dim: usize, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn ball_volume<N: Scalar>(dimension: usize, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
     let _pi: N = BaseFloat::pi();
-    _pi * radius.powi(dim as i32)
+    _pi * radius.powi(dimension as i32)
 }
 
 /// The area of a ball.
 #[inline]
-pub fn ball_area<N: Scalar>(dim: usize, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn ball_area<N: Scalar>(dimension: usize, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             let _pi: N = BaseFloat::pi();
             _pi * radius * na::cast(2.0f64)
@@ -36,18 +36,18 @@ pub fn ball_area<N: Scalar>(dim: usize, radius: N) -> N {
 
 /// The center of mass of a ball.
 #[inline]
-pub fn ball_center_of_mass<P: Orig>() -> P {
-    na::orig()
+pub fn ball_center_of_mass<P: Origin>() -> P {
+    na::origin()
 }
 
 /// The unit angular inertia of a ball.
 #[inline]
-pub fn ball_unit_angular_inertia<N, I>(dim: usize, radius: N) -> I
+pub fn ball_unit_angular_inertia<N, I>(dimension: usize, radius: N) -> I
     where N: Scalar,
           I: Zero + IndexMut<(usize, usize), Output = N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             let diag = radius * radius / na::cast(2.0f64);
             let mut res = na::zero::<I>();
@@ -71,14 +71,14 @@ pub fn ball_unit_angular_inertia<N, I>(dim: usize, radius: N) -> I
 }
 
 macro_rules! impl_volumetric_ball(
-    ($t: ident, $dim: expr, $p: ident, $i: ident) => {
+    ($t: ident, $dimension: expr, $p: ident, $i: ident) => {
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
             fn area(&self) -> N {
-                ball_area($dim, self.radius())
+                ball_area($dimension, self.radius())
             }
 
             fn volume(&self) -> N {
-                ball_volume($dim, self.radius())
+                ball_volume($dimension, self.radius())
             }
 
             fn center_of_mass(&self) -> $p<N> {
@@ -86,11 +86,11 @@ macro_rules! impl_volumetric_ball(
             }
 
             fn unit_angular_inertia(&self) -> $i<N> {
-                ball_unit_angular_inertia($dim, self.radius())
+                ball_unit_angular_inertia($dimension, self.radius())
             }
         }
     }
 );
 
-impl_volumetric_ball!(Ball2, 2, Pnt2, Mat1);
-impl_volumetric_ball!(Ball3, 3, Pnt3, Mat3);
+impl_volumetric_ball!(Ball2, 2, Point2, Matrix1);
+impl_volumetric_ball!(Ball3, 3, Point3, Matrix3);

--- a/src/volumetric/volumetric_ball.rs
+++ b/src/volumetric/volumetric_ball.rs
@@ -16,9 +16,9 @@ pub fn ball_volume<N: Scalar>(dim: usize, radius: N) -> N {
     _pi * radius.powi(dim as i32)
 }
 
-/// The surface of a ball.
+/// The area of a ball.
 #[inline]
-pub fn ball_surface<N: Scalar>(dim: usize, radius: N) -> N {
+pub fn ball_area<N: Scalar>(dim: usize, radius: N) -> N {
     assert!(dim == 2 || dim == 3);
 
     match dim {
@@ -73,8 +73,8 @@ pub fn ball_unit_angular_inertia<N, I>(dim: usize, radius: N) -> I
 macro_rules! impl_volumetric_ball(
     ($t: ident, $dim: expr, $p: ident, $i: ident) => {
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
-            fn surface(&self) -> N {
-                ball_surface($dim, self.radius())
+            fn area(&self) -> N {
+                ball_area($dim, self.radius())
             }
 
             fn volume(&self) -> N {

--- a/src/volumetric/volumetric_compound.rs
+++ b/src/volumetric/volumetric_compound.rs
@@ -1,4 +1,4 @@
-use na::{Pnt2, Pnt3, Mat1, Mat3};
+use na::{Point2, Point3, Matrix1, Matrix3};
 use na;
 use ncollide::shape::{Compound2, Compound3};
 use ncollide::math::Scalar;
@@ -29,8 +29,8 @@ macro_rules! impl_volumetric_compound(
 
             fn center_of_mass(&self) -> $p {
                 let mut mtot = na::zero::<N>();
-                let mut ctot = na::orig::<$p>();
-                let mut gtot = na::orig::<$p>(); // geometric center.
+                let mut ctot = na::origin::<$p>();
+                let mut gtot = na::origin::<$p>(); // geometric center.
 
                 let shapes = self.shapes();
 
@@ -38,8 +38,8 @@ macro_rules! impl_volumetric_compound(
                     let (mpart, cpart, _) = s.mass_properties(na::one());
 
                     mtot = mtot + mpart;
-                    ctot = ctot + (*m * cpart * mpart).to_vec();
-                    gtot = gtot + (*m * cpart).to_vec();
+                    ctot = ctot + (*m * cpart * mpart).to_vector();
+                    gtot = gtot + (*m * cpart).to_vector();
                 }
 
                 if na::is_zero(&mtot) {
@@ -60,7 +60,7 @@ macro_rules! impl_volumetric_compound(
                     let (mpart, cpart, ipart) = s.mass_properties(na::one());
 
                     itot = itot + ipart.to_world_space(m)
-                                       .to_relative_wrt_point(mpart, &(*m * cpart + (-*com.as_vec())));
+                                       .to_relative_wrt_point(mpart, &(*m * cpart + (-*com.as_vector())));
                 }
 
                 itot
@@ -73,16 +73,16 @@ macro_rules! impl_volumetric_compound(
             fn mass_properties(&self, density: N) -> (N, $p, $i) {
                 let mut mtot = na::zero::<N>();
                 let mut itot = na::zero::<$i>();
-                let mut ctot = na::orig::<$p>();
-                let mut gtot = na::orig::<$p>(); // geometric center.
+                let mut ctot = na::origin::<$p>();
+                let mut gtot = na::origin::<$p>(); // geometric center.
 
                 let shapes = self.shapes();
                 let props: Vec<_> = shapes.iter().map(|&(_, ref s)| s.mass_properties(na::one())).collect();
 
                 for (&(ref m, _), &(ref mpart, ref cpart, _)) in shapes.iter().zip(props.iter()) {
                     mtot = mtot + *mpart;
-                    ctot = ctot + (*m * *cpart * *mpart).to_vec();
-                    gtot = gtot + (*m * *cpart).to_vec();
+                    ctot = ctot + (*m * *cpart * *mpart).to_vector();
+                    gtot = gtot + (*m * *cpart).to_vector();
                 }
 
                 if na::is_zero(&mtot) {
@@ -93,7 +93,7 @@ macro_rules! impl_volumetric_compound(
                 }
 
                 for (&(ref m, _), &(ref mpart, ref cpart, ref ipart)) in shapes.iter().zip(props.iter()) {
-                    itot = itot + ipart.to_world_space(m).to_relative_wrt_point(*mpart, &(*m * *cpart + (-*ctot.as_vec())));
+                    itot = itot + ipart.to_world_space(m).to_relative_wrt_point(*mpart, &(*m * *cpart + (-*ctot.as_vector())));
                 }
 
                 (mtot * density, ctot, itot * density)
@@ -102,5 +102,5 @@ macro_rules! impl_volumetric_compound(
     )
 );
 
-impl_volumetric_compound!(Compound2<N>, Pnt2<N>, Mat1<N>);
-impl_volumetric_compound!(Compound3<N>, Pnt3<N>, Mat3<N>);
+impl_volumetric_compound!(Compound2<N>, Point2<N>, Matrix1<N>);
+impl_volumetric_compound!(Compound3<N>, Point3<N>, Matrix3<N>);

--- a/src/volumetric/volumetric_compound.rs
+++ b/src/volumetric/volumetric_compound.rs
@@ -7,11 +7,11 @@ use volumetric::{Volumetric, InertiaTensor};
 macro_rules! impl_volumetric_compound(
     ($t: ty, $p: ty, $i: ty) => (
         impl<N: Scalar> Volumetric<N, $p, $i> for $t {
-            fn surface(&self) -> N {
+            fn area(&self) -> N {
                 let mut stot: N = na::zero();
 
                 for &(_, ref s) in self.shapes().iter() {
-                    stot = stot + s.surface()
+                    stot = stot + s.area()
                 }
 
                 stot

--- a/src/volumetric/volumetric_cone.rs
+++ b/src/volumetric/volumetric_cone.rs
@@ -23,9 +23,9 @@ pub fn cone_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
     }
 }
 
-/// The surface of a cone.
+/// The area of a cone.
 #[inline]
-pub fn cone_surface<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
+pub fn cone_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
     assert!(dim == 2 || dim == 3);
 
     match dim {
@@ -97,8 +97,8 @@ pub fn cone_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N) ->
 macro_rules! impl_volumetric_cone(
     ($t: ident, $dim: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
-            fn surface(&self) -> N {
-                cone_surface($dim, self.half_height(), self.radius())
+            fn area(&self) -> N {
+                cone_area($dim, self.half_height(), self.radius())
             }
 
             fn volume(&self) -> N {

--- a/src/volumetric/volumetric_cone.rs
+++ b/src/volumetric/volumetric_cone.rs
@@ -1,6 +1,6 @@
 use std::ops::IndexMut;
 use num::Zero;
-use na::{BaseFloat, Orig, Pnt2, Pnt3, Mat1, Mat3};
+use na::{BaseFloat, Origin, Point2, Point3, Matrix1, Matrix3};
 use na;
 use ncollide::shape::{Cone2, Cone3};
 use ncollide::math::Scalar;
@@ -9,10 +9,10 @@ use volumetric::Volumetric;
 
 /// The volume of a cone.
 #[inline]
-pub fn cone_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn cone_volume<N: Scalar>(dimension: usize, half_height: N, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             radius * half_height * na::cast(2.0f64)
         }
@@ -25,10 +25,10 @@ pub fn cone_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
 
 /// The area of a cone.
 #[inline]
-pub fn cone_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn cone_area<N: Scalar>(dimension: usize, half_height: N, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             let height = half_height * na::cast(2.0f64);
             let side   = (height * height + radius * radius).sqrt();
@@ -50,8 +50,8 @@ pub fn cone_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
 #[inline]
 pub fn cone_center_of_mass<N, P>(half_height: N) -> P
     where N: Scalar,
-          P: Orig + IndexMut<usize, Output = N> {
-    let mut com = na::orig::<P>();
+          P: Origin + IndexMut<usize, Output = N> {
+    let mut com = na::origin::<P>();
     com[1] = -half_height / na::cast(2.0f64);
 
     com
@@ -59,12 +59,12 @@ pub fn cone_center_of_mass<N, P>(half_height: N) -> P
 
 /// The unit angular inertia of a cone.
 #[inline]
-pub fn cone_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N) -> I
+pub fn cone_unit_angular_inertia<N, I>(dimension: usize, half_height: N, radius: N) -> I
     where N: Scalar,
           I: Zero + IndexMut<(usize, usize), Output = N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             // FIXME: not sure about that…
             let mut res = na::zero::<I>();
@@ -95,14 +95,14 @@ pub fn cone_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N) ->
 }
 
 macro_rules! impl_volumetric_cone(
-    ($t: ident, $dim: expr, $p: ident, $i: ident) => (
+    ($t: ident, $dimension: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
             fn area(&self) -> N {
-                cone_area($dim, self.half_height(), self.radius())
+                cone_area($dimension, self.half_height(), self.radius())
             }
 
             fn volume(&self) -> N {
-                cone_volume($dim, self.half_height(), self.radius())
+                cone_volume($dimension, self.half_height(), self.radius())
             }
 
             fn center_of_mass(&self) -> $p<N> {
@@ -110,11 +110,11 @@ macro_rules! impl_volumetric_cone(
             }
 
             fn unit_angular_inertia(&self) -> $i<N> {
-                cone_unit_angular_inertia($dim, self.half_height(), self.radius())
+                cone_unit_angular_inertia($dimension, self.half_height(), self.radius())
             }
         }
     )
 );
 
-impl_volumetric_cone!(Cone2, 2, Pnt2, Mat1);
-impl_volumetric_cone!(Cone3, 3, Pnt3, Mat3);
+impl_volumetric_cone!(Cone2, 2, Point2, Matrix1);
+impl_volumetric_cone!(Cone3, 3, Point3, Matrix3);

--- a/src/volumetric/volumetric_convex.rs
+++ b/src/volumetric/volumetric_convex.rs
@@ -471,7 +471,7 @@ mod test {
         let geom = {
             let points = vec![Point2::new(half_a,  half_a), Point2::new(-half_a,  half_a),
                               Point2::new(-half_a, -half_a), Point2::new(half_a, -half_a) ];
-            Convex::new(points)
+            ConvexHull::new(points)
         };
         let actual = geom.unit_angular_inertia();
         assert!(na::approx_eq(&actual, &expected),
@@ -498,7 +498,7 @@ mod test {
         let geom = {
             let points = vec![Point2::new(half_a,  half_b), Point2::new(-half_a,  half_b),
                               Point2::new(-half_a, -half_b), Point2::new(half_a, -half_b) ];
-            Convex::new(points)
+            ConvexHull::new(points)
         };
         let actual = geom.unit_angular_inertia();
         assert!(na::approx_eq(&actual, &expected),
@@ -525,7 +525,7 @@ mod test {
         let geom = {
             let points = vec![Point2::new(0.0 - c_x, 0.0 - c_y), Point2::new(b - c_x, 0.0 - c_y),
                               Point2::new(a - c_x, h - c_y) ];
-            Convex::new(points)
+            ConvexHull::new(points)
         };
         let actual = geom.unit_angular_inertia();
         assert!(na::approx_eq(&actual, &expected),

--- a/src/volumetric/volumetric_cuboid.rs
+++ b/src/volumetric/volumetric_cuboid.rs
@@ -1,6 +1,6 @@
 use std::ops::{Index, IndexMut};
 use num::Zero;
-use na::{Pnt2, Pnt3, Mat1, Mat3, Orig, Iterable};
+use na::{Point2, Point3, Matrix1, Matrix3, Origin, Iterable};
 use na;
 use ncollide::shape::{Cuboid2, Cuboid3};
 use ncollide::math::Scalar;
@@ -9,10 +9,10 @@ use volumetric::Volumetric;
 
 /// The volume of a cuboid.
 #[inline]
-pub fn cuboid_volume<N, V>(dim: usize, half_extents: &V) -> N
+pub fn cuboid_volume<N, V>(dimension: usize, half_extents: &V) -> N
     where N: Scalar,
           V: Iterable<N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
     let mut res: N = na::one();
 
@@ -25,12 +25,12 @@ pub fn cuboid_volume<N, V>(dim: usize, half_extents: &V) -> N
 
 /// The area of a cuboid.
 #[inline]
-pub fn cuboid_area<N, V>(dim: usize, half_extents: &V) -> N
+pub fn cuboid_area<N, V>(dimension: usize, half_extents: &V) -> N
     where N: Scalar,
           V: Index<usize, Output = N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             (half_extents[0] + half_extents[1]) * na::cast(4.0f64)
         }
@@ -52,19 +52,19 @@ pub fn cuboid_area<N, V>(dim: usize, half_extents: &V) -> N
 
 /// The center of mass of a cuboid.
 #[inline]
-pub fn cuboid_center_of_mass<P: Orig>() -> P {
-    na::orig()
+pub fn cuboid_center_of_mass<P: Origin>() -> P {
+    na::origin()
 }
 
 /// The unit angular inertia of a cuboid.
 #[inline]
-pub fn cuboid_unit_angular_inertia<N, V, I>(dim: usize, half_extents: &V) -> I
+pub fn cuboid_unit_angular_inertia<N, V, I>(dimension: usize, half_extents: &V) -> I
     where N: Scalar,
           V: Index<usize, Output = N>,
           I: Zero + IndexMut<(usize, usize), Output = N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             let _2: N   = na::cast(2.0f64);
             let _i12: N = na::cast(1.0f64 / 12.0);
@@ -100,14 +100,14 @@ pub fn cuboid_unit_angular_inertia<N, V, I>(dim: usize, half_extents: &V) -> I
 }
 
 macro_rules! impl_volumetric_cuboid(
-    ($t: ident, $dim: expr, $p: ident, $i: ident) => (
+    ($t: ident, $dimension: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
             fn area(&self) -> N {
-                cuboid_area($dim, self.half_extents())
+                cuboid_area($dimension, self.half_extents())
             }
 
             fn volume(&self) -> N {
-                cuboid_volume($dim, self.half_extents())
+                cuboid_volume($dimension, self.half_extents())
             }
 
             fn center_of_mass(&self) -> $p<N> {
@@ -115,11 +115,11 @@ macro_rules! impl_volumetric_cuboid(
             }
 
             fn unit_angular_inertia(&self) -> $i<N> {
-                cuboid_unit_angular_inertia($dim, self.half_extents())
+                cuboid_unit_angular_inertia($dimension, self.half_extents())
             }
         }
     )
 );
 
-impl_volumetric_cuboid!(Cuboid2, 2, Pnt2, Mat1);
-impl_volumetric_cuboid!(Cuboid3, 3, Pnt3, Mat3);
+impl_volumetric_cuboid!(Cuboid2, 2, Point2, Matrix1);
+impl_volumetric_cuboid!(Cuboid3, 3, Point3, Matrix3);

--- a/src/volumetric/volumetric_cuboid.rs
+++ b/src/volumetric/volumetric_cuboid.rs
@@ -23,9 +23,9 @@ pub fn cuboid_volume<N, V>(dim: usize, half_extents: &V) -> N
     res
 }
 
-/// The surface of a cuboid.
+/// The area of a cuboid.
 #[inline]
-pub fn cuboid_surface<N, V>(dim: usize, half_extents: &V) -> N
+pub fn cuboid_area<N, V>(dim: usize, half_extents: &V) -> N
     where N: Scalar,
           V: Index<usize, Output = N> {
     assert!(dim == 2 || dim == 3);
@@ -102,8 +102,8 @@ pub fn cuboid_unit_angular_inertia<N, V, I>(dim: usize, half_extents: &V) -> I
 macro_rules! impl_volumetric_cuboid(
     ($t: ident, $dim: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
-            fn surface(&self) -> N {
-                cuboid_surface($dim, self.half_extents())
+            fn area(&self) -> N {
+                cuboid_area($dim, self.half_extents())
             }
 
             fn volume(&self) -> N {

--- a/src/volumetric/volumetric_cylinder.rs
+++ b/src/volumetric/volumetric_cylinder.rs
@@ -1,6 +1,6 @@
 use std::ops::IndexMut;
 use num::Zero;
-use na::{BaseFloat, Orig, Pnt2, Pnt3, Mat1, Mat3};
+use na::{BaseFloat, Origin, Point2, Point3, Matrix1, Matrix3};
 use na;
 use ncollide::shape::{Cylinder2, Cylinder3};
 use ncollide::math::Scalar;
@@ -9,10 +9,10 @@ use volumetric::Volumetric;
 
 /// The volume of a cylinder.
 #[inline]
-pub fn cylinder_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn cylinder_volume<N: Scalar>(dimension: usize, half_height: N, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             half_height * radius * na::cast(4.0f64)
         }
@@ -25,10 +25,10 @@ pub fn cylinder_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
 
 /// The area of a cylinder.
 #[inline]
-pub fn cylinder_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
-    assert!(dim == 2 || dim == 3);
+pub fn cylinder_area<N: Scalar>(dimension: usize, half_height: N, radius: N) -> N {
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             (half_height + radius) * na::cast(2.0f64)
         }
@@ -45,18 +45,18 @@ pub fn cylinder_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
 
 /// The center of mass of a cylinder.
 #[inline]
-pub fn cylinder_center_of_mass<P: Orig>() -> P {
-    na::orig()
+pub fn cylinder_center_of_mass<P: Origin>() -> P {
+    na::origin()
 }
 
 /// The unit angular inertia of a cylinder.
 #[inline]
-pub fn cylinder_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N) -> I
+pub fn cylinder_unit_angular_inertia<N, I>(dimension: usize, half_height: N, radius: N) -> I
     where N: Scalar,
           I: Zero + IndexMut<(usize, usize), Output = N> {
-    assert!(dim == 2 || dim == 3);
+    assert!(dimension == 2 || dimension == 3);
 
-    match dim {
+    match dimension {
         2 => {
             // Same a the rectangle.
             let _2:   N = na::cast(2.0f64);
@@ -89,14 +89,14 @@ pub fn cylinder_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N
 }
 
 macro_rules! impl_volumetric_cylinder(
-    ($t: ident, $dim: expr, $p: ident, $i: ident) => (
+    ($t: ident, $dimension: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
             fn area(&self) -> N {
-                cylinder_area($dim, self.half_height(), self.radius())
+                cylinder_area($dimension, self.half_height(), self.radius())
             }
 
             fn volume(&self) -> N {
-                cylinder_volume($dim, self.half_height(), self.radius())
+                cylinder_volume($dimension, self.half_height(), self.radius())
             }
 
             fn center_of_mass(&self) -> $p<N> {
@@ -104,11 +104,11 @@ macro_rules! impl_volumetric_cylinder(
             }
 
             fn unit_angular_inertia(&self) -> $i<N> {
-                cylinder_unit_angular_inertia($dim, self.half_height(), self.radius())
+                cylinder_unit_angular_inertia($dimension, self.half_height(), self.radius())
             }
         }
     )
 );
 
-impl_volumetric_cylinder!(Cylinder2, 2, Pnt2, Mat1);
-impl_volumetric_cylinder!(Cylinder3, 3, Pnt3, Mat3);
+impl_volumetric_cylinder!(Cylinder2, 2, Point2, Matrix1);
+impl_volumetric_cylinder!(Cylinder3, 3, Point3, Matrix3);

--- a/src/volumetric/volumetric_cylinder.rs
+++ b/src/volumetric/volumetric_cylinder.rs
@@ -23,9 +23,9 @@ pub fn cylinder_volume<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
     }
 }
 
-/// The surface of a cylinder.
+/// The area of a cylinder.
 #[inline]
-pub fn cylinder_surface<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
+pub fn cylinder_area<N: Scalar>(dim: usize, half_height: N, radius: N) -> N {
     assert!(dim == 2 || dim == 3);
 
     match dim {
@@ -91,8 +91,8 @@ pub fn cylinder_unit_angular_inertia<N, I>(dim: usize, half_height: N, radius: N
 macro_rules! impl_volumetric_cylinder(
     ($t: ident, $dim: expr, $p: ident, $i: ident) => (
         impl<N: Scalar> Volumetric<N, $p<N>, $i<N>> for $t<N> {
-            fn surface(&self) -> N {
-                cylinder_surface($dim, self.half_height(), self.radius())
+            fn area(&self) -> N {
+                cylinder_area($dim, self.half_height(), self.radius())
             }
 
             fn volume(&self) -> N {

--- a/src/volumetric/volumetric_repr.rs
+++ b/src/volumetric/volumetric_repr.rs
@@ -1,5 +1,5 @@
-use na::{Pnt2, Iso2, Pnt3, Mat3, Iso3, Mat1};
-use ncollide::shape::{Ball, Cone, Cylinder, Convex2, Convex3, Cuboid2, Cuboid3, Compound2, Compound3};
+use na::{Point2, Isometry2, Point3, Matrix3, Isometry3, Matrix1};
+use ncollide::shape::{Ball, Cone, Cylinder, ConvexHull2, ConvexHull3, Cuboid2, Cuboid3, Compound2, Compound3};
 use ncollide::inspection::Repr;
 use ncollide::math::Scalar;
 use volumetric::Volumetric;
@@ -37,48 +37,48 @@ macro_rules! dispatch(
     }
 );
 
-impl<N> Volumetric<N, Pnt2<N>, Mat1<N>> for Repr<Pnt2<N>, Iso2<N>>
+impl<N> Volumetric<N, Point2<N>, Matrix1<N>> for Repr<Point2<N>, Isometry2<N>>
     where N: Scalar {
     fn area(&self) -> N {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.area())
+        dispatch!(Point2<N>, Matrix1<N>, Compound2<N>, ConvexHull2<N>, Cuboid2<N>, self.area())
     }
 
     fn volume(&self) -> N {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.volume())
+        dispatch!(Point2<N>, Matrix1<N>, Compound2<N>, ConvexHull2<N>, Cuboid2<N>, self.volume())
     }
 
-    fn center_of_mass(&self) -> Pnt2<N> {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.center_of_mass())
+    fn center_of_mass(&self) -> Point2<N> {
+        dispatch!(Point2<N>, Matrix1<N>, Compound2<N>, ConvexHull2<N>, Cuboid2<N>, self.center_of_mass())
     }
 
-    fn unit_angular_inertia(&self) -> Mat1<N> {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.unit_angular_inertia())
+    fn unit_angular_inertia(&self) -> Matrix1<N> {
+        dispatch!(Point2<N>, Matrix1<N>, Compound2<N>, ConvexHull2<N>, Cuboid2<N>, self.unit_angular_inertia())
     }
 
-    fn mass_properties(&self, density: N) -> (N, Pnt2<N>, Mat1<N>) {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.mass_properties(density))
+    fn mass_properties(&self, density: N) -> (N, Point2<N>, Matrix1<N>) {
+        dispatch!(Point2<N>, Matrix1<N>, Compound2<N>, ConvexHull2<N>, Cuboid2<N>, self.mass_properties(density))
     }
 }
 
-impl<N> Volumetric<N, Pnt3<N>, Mat3<N>> for Repr<Pnt3<N>, Iso3<N>>
+impl<N> Volumetric<N, Point3<N>, Matrix3<N>> for Repr<Point3<N>, Isometry3<N>>
     where N: Scalar {
     fn area(&self) -> N {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.area())
+        dispatch!(Point3<N>, Matrix3<N>, Compound3<N>, ConvexHull3<N>, Cuboid3<N>, self.area())
     }
 
     fn volume(&self) -> N {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.volume())
+        dispatch!(Point3<N>, Matrix3<N>, Compound3<N>, ConvexHull3<N>, Cuboid3<N>, self.volume())
     }
 
-    fn center_of_mass(&self) -> Pnt3<N> {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.center_of_mass())
+    fn center_of_mass(&self) -> Point3<N> {
+        dispatch!(Point3<N>, Matrix3<N>, Compound3<N>, ConvexHull3<N>, Cuboid3<N>, self.center_of_mass())
     }
 
-    fn unit_angular_inertia(&self) -> Mat3<N> {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.unit_angular_inertia())
+    fn unit_angular_inertia(&self) -> Matrix3<N> {
+        dispatch!(Point3<N>, Matrix3<N>, Compound3<N>, ConvexHull3<N>, Cuboid3<N>, self.unit_angular_inertia())
     }
 
-    fn mass_properties(&self, density: N) -> (N, Pnt3<N>, Mat3<N>) {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.mass_properties(density))
+    fn mass_properties(&self, density: N) -> (N, Point3<N>, Matrix3<N>) {
+        dispatch!(Point3<N>, Matrix3<N>, Compound3<N>, ConvexHull3<N>, Cuboid3<N>, self.mass_properties(density))
     }
 }

--- a/src/volumetric/volumetric_repr.rs
+++ b/src/volumetric/volumetric_repr.rs
@@ -1,5 +1,5 @@
 use na::{Pnt2, Iso2, Pnt3, Mat3, Iso3, Mat1};
-use ncollide::shape::{Ball, Cone, Cylinder, Convex3, Cuboid2, Cuboid3, Compound2, Compound3};
+use ncollide::shape::{Ball, Cone, Cylinder, Convex2, Convex3, Cuboid2, Cuboid3, Compound2, Compound3};
 use ncollide::inspection::Repr;
 use ncollide::math::Scalar;
 use volumetric::Volumetric;
@@ -39,41 +39,31 @@ macro_rules! dispatch(
 
 impl<N> Volumetric<N, Pnt2<N>, Mat1<N>> for Repr<Pnt2<N>, Iso2<N>>
     where N: Scalar {
-    fn surface(&self) -> N {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Cuboid2<N>/* Convex2<N> */, Cuboid2<N>, self.surface())
-        //                                              XXX:   ^^^^^^^^^^
-        //                                              Change this when Volumetric is implemented for 2D convex.
+    fn area(&self) -> N {
+        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.area())
     }
 
     fn volume(&self) -> N {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Cuboid2<N>/* Convex2<N> */, Cuboid2<N>, self.volume())
-        //                                              XXX:   ^^^^^^^^^^
-        //                                              Change this when Volumetric is implemented for 2D convex.
+        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.volume())
     }
 
     fn center_of_mass(&self) -> Pnt2<N> {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Cuboid2<N>/* Convex2<N> */, Cuboid2<N>, self.center_of_mass())
-        //                                              XXX:   ^^^^^^^^^^
-        //                                              Change this when Volumetric is implemented for 2D convex.
+        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.center_of_mass())
     }
 
     fn unit_angular_inertia(&self) -> Mat1<N> {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Cuboid2<N>/* Convex2<N> */, Cuboid2<N>, self.unit_angular_inertia())
-        //                                              XXX:   ^^^^^^^^^^
-        //                                              Change this when Volumetric is implemented for 2D convex.
+        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.unit_angular_inertia())
     }
 
     fn mass_properties(&self, density: N) -> (N, Pnt2<N>, Mat1<N>) {
-        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Cuboid2<N>/* Convex2<N> */, Cuboid2<N>, self.mass_properties(density))
-        //                                              XXX:   ^^^^^^^^^^
-        //                                              Change this when Volumetric is implemented for 2D convex.
+        dispatch!(Pnt2<N>, Mat1<N>, Compound2<N>, Convex2<N>, Cuboid2<N>, self.mass_properties(density))
     }
 }
 
 impl<N> Volumetric<N, Pnt3<N>, Mat3<N>> for Repr<Pnt3<N>, Iso3<N>>
     where N: Scalar {
-    fn surface(&self) -> N {
-        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.surface())
+    fn area(&self) -> N {
+        dispatch!(Pnt3<N>, Mat3<N>, Compound3<N>, Convex3<N>, Cuboid3<N>, self.area())
     }
 
     fn volume(&self) -> N {

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,6 +1,6 @@
 //! The physics world.
 
+pub use world::world::{World, WorldBroadPhase, RigidBodies, RigidBodyCollisionWorld,
+                       WorldCollisionObject};
+
 mod world;
-
-pub use world::world::{World, WorldBroadPhase, RigidBodyCollisionWorld/*, RigidBodies*/};
-

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -7,43 +7,49 @@ use ncollide::math::Scalar;
 use ncollide::bounding_volume::AABB;
 use ncollide::utils::data::hash_map::{HashMap, Entry};
 use ncollide::utils::data::hash::UintTWHash;
-use ncollide::broad_phase::{BroadPhase, DBVTBroadPhase};
-use ncollide::narrow_phase::ContactSignalHandler;
-use ncollide::world::{CollisionWorld, CollisionObject};
+use ncollide::broad_phase::{BroadPhase, DBVTBroadPhase, BroadPhasePairFilter};
+use ncollide::narrow_phase::{ContactSignalHandler, ProximitySignalHandler, DefaultNarrowPhase,
+                             DefaultCollisionDispatcher, DefaultProximityDispatcher};
+use ncollide::world::{CollisionWorld, CollisionObject, CollisionQueryType};
 use integration::{Integrator, BodySmpEulerIntegrator, BodyForceGenerator,
                   TranslationalCCDMotionClamping};
-use detection::ActivationManager;
-use detection::Detector;
+use detection::{ActivationManager, Detector};
 use detection::constraint::Constraint;
 use detection::joint::{JointManager, BallInSocket, Fixed};
 use resolution::{Solver, AccumulatedImpulseSolver, CorrectionMode};
-use object::{RigidBody, RigidBodyHandle};
+use object::{WorldObject, RigidBody, RigidBodyHandle, Sensor, SensorHandle};
 use math::{Point, Vector, Matrix};
 
 /// The default broad phase.
-pub type WorldBroadPhase<N> = DBVTBroadPhase<Point<N>, RigidBodyHandle<N>, AABB<Point<N>>>;
+pub type WorldBroadPhase<N> = DBVTBroadPhase<Point<N>, WorldObject<N>, AABB<Point<N>>>;
+
 /// An iterator visiting rigid bodies.
 pub type RigidBodies<'a, N> = Map<Iter<'a, Entry<usize, RigidBodyHandle<N>>>, fn(&'a Entry<usize, RigidBodyHandle<N>>) -> &'a RigidBodyHandle<N>>;
 
-/// Type of the collision world containing rigid bodies.
-pub type RigidBodyCollisionWorld<N> = CollisionWorld<Point<N>, Matrix<N>, RigidBodyHandle<N>>;
+/// An iterator visiting sensors.
+pub type Sensors<'a, N> = Map<Iter<'a, Entry<usize, SensorHandle<N>>>, fn(&'a Entry<usize, SensorHandle<N>>) -> &'a SensorHandle<N>>;
 
-/// Type of a collision object containing a rigid body as its data.
-pub type RigidBodyCollisionObject<N> = CollisionObject<Point<N>, Matrix<N>, RigidBodyHandle<N>>;
+/// Type of the collision world containing rigid bodies.
+pub type RigidBodyCollisionWorld<N> = CollisionWorld<Point<N>, Matrix<N>, WorldObject<N>>;
+
+/// Type of a collision object containing `WorldObject` body as its data.
+pub type WorldCollisionObject<N> = CollisionObject<Point<N>, Matrix<N>, WorldObject<N>>;
 
 
 /// The physical world.
 ///
 /// This is the main structure of the physics engine.
 pub struct World<N: Scalar> {
-    cworld:      RigidBodyCollisionWorld<N>,
-    bodies:      HashMap<usize, RigidBodyHandle<N>, UintTWHash>,
-    forces:      BodyForceGenerator<N>,
-    integrator:  BodySmpEulerIntegrator,
-    sleep:       Rc<RefCell<ActivationManager<N>>>, // FIXME: avoid sharing (needed for the contact signal handler)
-    ccd:         TranslationalCCDMotionClamping<N>,
-    joints:      JointManager<N>,
-    solver:      AccumulatedImpulseSolver<N>,
+    cworld:       RigidBodyCollisionWorld<N>,
+    rigid_bodies: HashMap<usize, RigidBodyHandle<N>, UintTWHash>,
+    sensors:      HashMap<usize, SensorHandle<N>, UintTWHash>,
+    forces:       BodyForceGenerator<N>,
+    integrator:   BodySmpEulerIntegrator,
+    sleep:        Rc<RefCell<ActivationManager<N>>>, // FIXME: avoid sharing (needed for the contact signal handler)
+    ccd:          TranslationalCCDMotionClamping<N>,
+    joints:       JointManager<N>,
+    solver:       AccumulatedImpulseSolver<N>,
+    prediction:   N
 }
 
 impl<N: Scalar> World<N> {
@@ -53,6 +59,8 @@ impl<N: Scalar> World<N> {
          * Setup the physics world
          */
 
+        let prediction = na::cast(0.02f64); // FIXME: do not hard-code the prediction margin.
+
         // For the intergration
         let forces     = BodyForceGenerator::new(na::zero(), na::zero());
         let integrator = BodySmpEulerIntegrator::new();
@@ -61,7 +69,13 @@ impl<N: Scalar> World<N> {
          * For the collision detection
          */
         // Collision world
-        let mut cworld = CollisionWorld::new(na::cast(0.10f64), na::cast(0.10f64), false);
+        let mut cworld = CollisionWorld::new(prediction, false);
+
+        // Custom narrow phase.
+        let disp = DefaultCollisionDispatcher::new();
+        let prox = DefaultProximityDispatcher::new();
+        let nf   = DefaultNarrowPhase::new(Box::new(disp), Box::new(prox));
+        let _    = cworld.set_narrow_phase(Box::new(nf));
 
         // CCD handler
         let ccd = TranslationalCCDMotionClamping::new();
@@ -70,8 +84,14 @@ impl<N: Scalar> World<N> {
         let sleep = Rc::new(RefCell::new(ActivationManager::new(na::cast(0.01f64))));
 
         // Setup contact handler to reactivate sleeping objects that loose contact.
-        let handler = ObjectActivationOnContactHandler::new(sleep.clone());
+        let handler = ObjectActivationOnContactHandler { sleep: sleep.clone() };
         cworld.register_contact_signal_handler("__nphysics_internal_ObjectActivationOnContactHandler", handler);
+
+        // Setup the broad phase pair filter that will prevent sensors from colliding with their
+        // parent.
+        let filter      = SensorsNotCollidingTheirParentPairFilter;
+        let filter_name = "__nphysics_internal_SensorsNotCollidingTheirParentPairFilter";
+        cworld.register_broad_phase_pair_filter(filter_name, filter);
 
         // Joints
         let joints = JointManager::new();
@@ -88,20 +108,22 @@ impl<N: Scalar> World<N> {
             10);
 
         World {
-            cworld:     cworld,
-            bodies:     HashMap::new(UintTWHash::new()),
-            forces:     forces,
-            integrator: integrator,
-            sleep:      sleep,
-            ccd:        ccd,
-            joints:     joints,
-            solver:     solver,
+            cworld:       cworld,
+            rigid_bodies: HashMap::new(UintTWHash::new()),
+            sensors:      HashMap::new(UintTWHash::new()),
+            forces:       forces,
+            integrator:   integrator,
+            sleep:        sleep,
+            ccd:          ccd,
+            joints:       joints,
+            solver:       solver,
+            prediction:   prediction
         }
     }
 
     /// Updates the physics world.
     pub fn step(&mut self, dt: N) {
-        for e in self.bodies.elements_mut().iter_mut() {
+        for e in self.rigid_bodies.elements_mut().iter_mut() {
             let mut rb = e.value.borrow_mut();
 
             if rb.is_active() {
@@ -112,30 +134,44 @@ impl<N: Scalar> World<N> {
             }
         }
 
+        for e in self.sensors.elements_mut().iter_mut() {
+            let sensor = e.value.borrow_mut();
+
+            if let Some(rb) = sensor.parent() {
+                if rb.borrow().is_active() {
+                    self.cworld.deferred_set_position(&*e.value as *const RefCell<Sensor<N>> as usize,
+                                                      sensor.position());
+                }
+            }
+        }
+
         self.cworld.perform_position_update();
         self.cworld.perform_broad_phase();
-        self.ccd.update(&mut self.cworld);
-        self.cworld.perform_narrow_phase();
+        if !self.ccd.update(&mut self.cworld) {
+            self.cworld.perform_narrow_phase();
+        }
 
         self.joints.update(&mut *self.sleep.borrow_mut());
-        self.sleep.borrow_mut().update(&mut self.cworld, &self.joints, &self.bodies);
+        self.sleep.borrow_mut().update(&mut self.cworld, &self.joints, &self.rigid_bodies);
 
         // XXX: use `self.collector` instead to avoid allocation.
         let mut collector = Vec::new();
 
         for (b1, b2, c) in self.cworld.contacts() {
-            if b1.data.borrow().is_active() || b2.data.borrow().is_active() {
-                let m1 = b1.data.borrow().margin();
-                let m2 = b2.data.borrow().margin();
+            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
+                if rb1.borrow().is_active() || rb2.borrow().is_active() {
+                    let m1 = rb1.borrow().margin();
+                    let m2 = rb2.borrow().margin();
 
-                let mut c = c.clone();
-                c.depth = c.depth + m1 + m2;
+                    let mut c = c.clone();
+                    c.depth = c.depth + m1 + m2;
 
-                collector.push(Constraint::RBRB(b1.data.clone(), b2.data.clone(), c));
+                    collector.push(Constraint::RBRB(rb1.clone(), rb2.clone(), c));
+                }
             }
         }
 
-        self.joints.interferences(&mut collector);
+        self.joints.constraints(&mut collector);
 
         self.solver.solve(dt, &collector[..]);
 
@@ -143,29 +179,56 @@ impl<N: Scalar> World<N> {
     }
 
     /// Adds a rigid body to the physics world.
-    pub fn add_body(&mut self, rb: RigidBody<N>) -> RigidBodyHandle<N> {
+    pub fn add_rigid_body(&mut self, rb: RigidBody<N>) -> RigidBodyHandle<N> {
         let position = rb.position().clone();
         let shape = rb.shape().clone();
         let groups = rb.collision_groups().as_collision_groups().clone();
-
+        let collision_object_prediction = rb.margin() + self.prediction / na::cast(2.0f64);
         let handle = Rc::new(RefCell::new(rb));
         let uid = &*handle as *const RefCell<RigidBody<N>> as usize;
 
-        self.bodies.insert(uid, handle.clone());
-        self.cworld.add(uid, position, shape, groups, handle.clone());
+        self.rigid_bodies.insert(uid, handle.clone());
+        self.cworld.add(uid, position, shape, groups,
+                        CollisionQueryType::Contacts(collision_object_prediction),
+                        WorldObject::RigidBody(handle.clone()));
+
+        handle
+    }
+
+    /// Adds a sensor to the physics world.
+    pub fn add_sensor(&mut self, sensor: Sensor<N>) -> SensorHandle<N> {
+        let position = sensor.position().clone();
+        let shape    = sensor.shape().clone();
+        let groups   = sensor.collision_groups().as_collision_groups().clone();
+        let margin   = sensor.margin();
+        let handle   = Rc::new(RefCell::new(sensor));
+        let uid      = &*handle as *const RefCell<Sensor<N>> as usize;
+
+        self.sensors.insert(uid, handle.clone());
+        self.cworld.add(uid, position, shape, groups,
+                        CollisionQueryType::Proximity(margin),
+                        WorldObject::Sensor(handle.clone()));
 
         handle
     }
 
     /// Remove a rigid body from the physics world.
-    pub fn remove_body(&mut self, b: &RigidBodyHandle<N>) {
-        let uid = &**b as *const RefCell<RigidBody<N>> as usize;
+    pub fn remove_rigid_body(&mut self, rb: &RigidBodyHandle<N>) {
+        let uid = &**rb as *const RefCell<RigidBody<N>> as usize;
         self.cworld.deferred_remove(uid);
         self.cworld.perform_removals_and_broad_phase();
-        self.joints.remove(b, &mut *self.sleep.borrow_mut());
-        self.ccd.remove_ccd_from(b);
-        self.bodies.remove(&uid);
-        b.borrow_mut().delete();
+        self.joints.remove(rb, &mut *self.sleep.borrow_mut());
+        self.ccd.remove_ccd_from(rb);
+        self.rigid_bodies.remove(&uid);
+        rb.borrow_mut().delete();
+    }
+
+    /// Remove a sensor from the physics world.
+    pub fn remove_sensor(&mut self, sensor: &SensorHandle<N>) {
+        let uid = &**sensor as *const RefCell<Sensor<N>> as usize;
+        self.cworld.deferred_remove(uid);
+        self.cworld.perform_removals_and_broad_phase();
+        self.sensors.remove(&uid);
     }
 
     // XXX: keep this reference mutable?
@@ -224,8 +287,11 @@ impl<N: Scalar> World<N> {
     }*/
 
     /// Adds continuous collision detection to the given rigid body.
-    pub fn add_ccd_to(&mut self, body: &RigidBodyHandle<N>, motion_thresold: N) {
-        self.ccd.add_ccd_to(body.clone(), motion_thresold)
+    ///
+    /// Set `trigger_sensor` to `true` if the rigid body should active the sensors that would have
+    /// been missed without CCD enabled.
+    pub fn add_ccd_to(&mut self, body: &RigidBodyHandle<N>, motion_thresold: N, trigger_sensors: bool) {
+        self.ccd.add_ccd_to(body.clone(), motion_thresold, trigger_sensors)
     }
 
     /// Adds a ball-in-socket joint to the world.
@@ -256,48 +322,63 @@ impl<N: Scalar> World<N> {
         self.joints.remove_joint(joint, &mut *self.sleep.borrow_mut())
     }
 
-    /// Collects every interferences detected since the last update.
-    pub fn interferences(&mut self, out: &mut Vec<Constraint<N>>) {
+    /// Collects every constraincts detected since the last update.
+    pub fn constraints(&mut self, out: &mut Vec<Constraint<N>>) {
         // FIXME: ugly.
         for (b1, b2, c) in self.cworld.contacts() {
-            let m1 = b1.data.borrow().margin();
-            let m2 = b2.data.borrow().margin();
+            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
+                let m1 = rb1.borrow().margin();
+                let m2 = rb2.borrow().margin();
 
-            let mut c = c.clone();
-            c.depth = c.depth + m1 + m2;
+                let mut c = c.clone();
+                c.depth = c.depth + m1 + m2;
 
-            out.push(Constraint::RBRB(b1.data.clone(), b2.data.clone(), c));
+                out.push(Constraint::RBRB(rb1.clone(), rb2.clone(), c));
+            }
         }
 
-        self.joints.interferences(out);
+        self.joints.constraints(out);
     }
 
     /// An iterator visiting all rigid bodies on this world.
-    pub fn bodies(&self) -> RigidBodies<N> {
+    pub fn rigid_bodies(&self) -> RigidBodies<N> {
         fn extract_value<N: Scalar>(e: &Entry<usize, RigidBodyHandle<N>>) -> &RigidBodyHandle<N> {
             &e.value
         }
 
         let extract_value_fn: fn(_) -> _ = extract_value;
-        self.bodies.elements().iter().map(extract_value_fn)
+        self.rigid_bodies.elements().iter().map(extract_value_fn)
     }
 
-    /* FIXME
-    /// Registers a handler for proximity start/stop events.
-    pub fn register_proximity_signal_handler<H>(&mut self, name: &str, handler: H)
-        where H: ProximitySignalHandler<RigidBodyHandle<N>> + 'static {
-        self.cworld.register_proximity_signal_handler(name, handler)
+    /// An iterator visiting all sensors on this world.
+    pub fn sensors(&self) -> Sensors<N> {
+        fn extract_value<N: Scalar>(e: &Entry<usize, SensorHandle<N>>) -> &SensorHandle<N> {
+            &e.value
+        }
+
+        let extract_value_fn: fn(_) -> _ = extract_value;
+        self.sensors.elements().iter().map(extract_value_fn)
     }
 
-    /// Unregisters a handler for proximity start/stop events.
-    pub fn unregister_proximity_signal_handler(&mut self, name: &str) {
-        self.cworld.unregister_proximity_signal_handler(name)
+    /// Adds a filter that tells if a potential collision pair should be ignored or not.
+    ///
+    /// The proximity filter returns `false` for a given pair of collision objects if they should
+    /// be ignored by the narrow phase. Keep in mind that modifying the proximity filter will have
+    /// a non-trivial overhead during the next update as it will force re-detection of all
+    /// collision pairs.
+    pub fn register_broad_phase_pair_filter<F>(&mut self, name: &str, filter: F)
+        where F: BroadPhasePairFilter<WorldCollisionObject<N>> + 'static {
+        self.cworld.register_broad_phase_pair_filter(name, filter)
     }
-    */
+
+    /// Removes the pair filter named `name`.
+    pub fn unregister_broad_phase_pair_filter(&mut self, name: &str) {
+        self.cworld.unregister_broad_phase_pair_filter(name)
+    }
 
     /// Registers a handler for contact start/stop events.
     pub fn register_contact_signal_handler<H>(&mut self, name: &str, handler: H)
-        where H: ContactSignalHandler<RigidBodyHandle<N>> + 'static {
+        where H: ContactSignalHandler<WorldObject<N>> + 'static {
         self.cworld.register_contact_signal_handler(name, handler)
     }
 
@@ -305,26 +386,56 @@ impl<N: Scalar> World<N> {
     pub fn unregister_contact_signal_handler(&mut self, name: &str) {
         self.cworld.unregister_contact_signal_handler(name)
     }
+
+    /// Registers a handler for proximity status change events.
+    pub fn register_proximity_signal_handler<H>(&mut self, name: &str, handler: H)
+        where H: ProximitySignalHandler<WorldObject<N>> + 'static {
+        self.cworld.register_proximity_signal_handler(name, handler);
+    }
+
+    /// Unregisters a handler for proximity status change events.
+    pub fn unregister_proximity_signal_handler(&mut self, name: &str) {
+        self.cworld.unregister_proximity_signal_handler(name);
+    }
 }
 
 struct ObjectActivationOnContactHandler<N: Scalar> {
     sleep: Rc<RefCell<ActivationManager<N>>>
 }
 
-impl<N: Scalar> ObjectActivationOnContactHandler<N> {
-    pub fn new(sleep: Rc<RefCell<ActivationManager<N>>>) -> ObjectActivationOnContactHandler<N> {
-        ObjectActivationOnContactHandler {
-            sleep: sleep
+impl<N: Scalar> ContactSignalHandler<WorldObject<N>> for ObjectActivationOnContactHandler<N> {
+    #[inline]
+    fn handle_contact(&mut self, b1: &WorldObject<N>, b2: &WorldObject<N>, started: bool) {
+        // Wake on collision lost.
+        if !started {
+            // There is no need to wake up anything if a rigid-body intersects a sensor.
+            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (b1, b2) {
+                self.sleep.borrow_mut().deferred_activate(rb1);
+                self.sleep.borrow_mut().deferred_activate(rb2);
+            }
         }
     }
 }
 
-impl<N: Scalar> ContactSignalHandler<RigidBodyHandle<N>> for ObjectActivationOnContactHandler<N> {
-    fn handle_contact(&mut self, b1: &RigidBodyHandle<N>, b2: &RigidBodyHandle<N>, started: bool) {
-        // Wake on collision lost.
-        if !started {
-            self.sleep.borrow_mut().deferred_activate(b1);
-            self.sleep.borrow_mut().deferred_activate(b2);
+struct SensorsNotCollidingTheirParentPairFilter;
+
+impl<N: Scalar> BroadPhasePairFilter<WorldCollisionObject<N>> for SensorsNotCollidingTheirParentPairFilter {
+    #[inline]
+    fn is_pair_valid(&self, b1: &WorldCollisionObject<N>, b2: &WorldCollisionObject<N>) -> bool {
+        match (&b1.data, &b2.data) {
+            (&WorldObject::RigidBody(ref rb), &WorldObject::Sensor(ref s)) |
+            (&WorldObject::Sensor(ref s), &WorldObject::RigidBody(ref rb)) => {
+                let bs = s.borrow();
+
+                if let Some(parent) = bs.parent() {
+                    WorldObject::rigid_body_uid(rb) != WorldObject::rigid_body_uid(parent) ||
+                    bs.proximity_with_parent_enabled()
+                }
+                else {
+                    true
+                }
+            },
+            _ => true
         }
     }
 }


### PR DESCRIPTION
This adds a first implementation of sensors. Some corner-cases are not yet handled (especially regarding CCD and modification-after-world-addition) but it is useful enough to be published. Sensors may optionally be linked to a rigid body.

See the `sensor.rs` examples for how to create a sensor. It is basically the same as adding rigid bodies, but with less parameters.

Fix #20.