### PR TITLE
Pin version numbers in examples

### DIFF
--- a/examples2d/Cargo.toml
+++ b/examples2d/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 [dependencies]
-num = "*"
+num = "0.1.*"
 rand = "*"
-nalgebra = "*"
-ncollide = "*"
+nalgebra = "0.9.*"
+ncollide = "0.10.*"
 
 [dependencies.nphysics_testbed2d]
 path = "./nphysics_testbed2d"

--- a/examples3d/Cargo.toml
+++ b/examples3d/Cargo.toml
@@ -5,9 +5,9 @@ authors = [ "Sébastien Crozet <developer@crozet.re>" ]
 
 [dependencies]
 rand = "*"
-num = "*"
-nalgebra = "*"
-ncollide = "*"
+num = "0.1.*"
+nalgebra = "0.9.*"
+ncollide = "0.10.*"
 kiss3d = "*"
 
 [dependencies.nphysics3d]


### PR DESCRIPTION
Currently the examples don't build, because `nphysics` pins the `nalgebra` and `ncollide` versions to `0.9.*` and `0.10.*` respectively, whereas the examples use wildcard dependency versions. This fixes that issue, and allows the examples to build again.