### PR TITLE
Update nalgebra/ncollide to 0.12

### DIFF
--- a/build/nphysics2d/Cargo.toml
+++ b/build/nphysics2d/Cargo.toml
@@ -22,8 +22,8 @@ path = "../../src/lib.rs"
 rustc-serialize = "0.3"
 num-traits = "0.1"
 alga       = "0.5"
-nalgebra   = "0.11"
-ncollide   = "0.11"
+nalgebra   = "0.12"
+ncollide   = "0.12"
 
 [dev-dependencies]
 approx     = "0.1"

--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -22,8 +22,8 @@ path = "../../src/lib.rs"
 rustc-serialize = "0.3"
 num-traits = "0.1"
 alga       = "0.5"
-nalgebra   = "0.11"
-ncollide   = "0.11"
+nalgebra   = "0.12"
+ncollide   = "0.12"
 
 [dev-dependencies]
 approx     = "0.1"


### PR DESCRIPTION
No changes were required.  Should we open the version bounds to include 0.11?