### PR TITLE
Allow users to choose threadsafe types instead of Rc<RefCell<T>>

### DIFF
--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -13,6 +13,7 @@ license = "BSD-3-Clause"
 [features]
 default = [ "dim3" ]
 dim3    = [ ]
+threadsafe = [ ]
 
 [lib]
 name = "nphysics3d"

--- a/examples2d/nphysics_testbed2d/src/engine.rs
+++ b/examples2d/nphysics_testbed2d/src/engine.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::sync::Arc;
 use std::collections::HashMap;
 use rand::{SeedableRng, XorShiftRng, Rng};
@@ -7,12 +5,13 @@ use sfml::graphics::RenderWindow;
 use na::{Point2, Point3, Isometry2};
 use na;
 use nphysics2d::object::{WorldObject, RigidBodyHandle, SensorHandle};
+use nphysics2d::Rc;
 use ncollide::transformation;
 use ncollide::shape::{Shape2, Plane2, Ball2, Cuboid2, Compound2, Polyline2, ConvexHull2, Segment2};
 use camera::Camera;
 use objects::{SceneNode, Ball, Box, Lines, Segment};
 
-pub type GraphicsManagerHandle = Rc<RefCell<GraphicsManager<'static>>>;
+pub type GraphicsManagerHandle = Rc<GraphicsManager<'static>>;
 
 pub struct GraphicsManager<'a> {
     // NOTE: sensors and rigid bodies are not on the same hashmap because we want do draw sensors

--- a/examples2d/nphysics_testbed2d/src/testbed.rs
+++ b/examples2d/nphysics_testbed2d/src/testbed.rs
@@ -1,6 +1,4 @@
 use std::env;
-use std::rc::Rc;
-use std::cell::RefCell;
 use sfml::graphics::{RenderWindow, RenderTarget, Font};
 use sfml::window::{ContextSettings, VideoMode};
 use sfml::window::window_style;
@@ -13,6 +11,7 @@ use ncollide::world::CollisionGroups;
 use nphysics2d::world::World;
 use nphysics2d::object::{WorldObject, RigidBodyHandle, SensorHandle};
 use nphysics2d::detection::joint::{Fixed, Anchor};
+use nphysics2d::Rc;
 use camera::Camera;
 use fps::Fps;
 use engine::{GraphicsManager, GraphicsManagerHandle};
@@ -65,7 +64,7 @@ struct TestbedState<'a> {
     camera: Camera,
     fps: Fps<'a>,
     grabbed_object: Option<RigidBodyHandle<f32>>,
-    grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>>,
+    grabbed_object_joint: Option<Rc<Fixed<f32>>>,
 }
 
 impl<'a> TestbedState<'a> {
@@ -94,7 +93,7 @@ impl Testbed {
             world:     World::new(),
             callbacks: [ None, None, None, None, None, None, None, None, None ],
             window:    window,
-            graphics:  Rc::new(RefCell::new(GraphicsManager::new()))
+            graphics:  Rc::new(GraphicsManager::new())
         }
     }
 

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::collections::HashMap;
 use rand::{SeedableRng, XorShiftRng, Rng};
 use na::{Point3, Isometry3};
@@ -9,7 +7,8 @@ use kiss3d::scene::SceneNode;
 use kiss3d::camera::{Camera, ArcBall, FirstPerson};
 use ncollide::shape::{Shape3, Plane3, Ball3, Cuboid3, Cylinder3, Cone3, Compound3, TriMesh3, ConvexHull3};
 use ncollide::transformation;
-use nphysics3d::object::{RigidBody, WorldObject, WorldObjectBorrowed, RigidBodyHandle, SensorHandle};
+use nphysics3d::object::{WorldObject, WorldObjectBorrowed, RigidBodyHandle, SensorHandle};
+use nphysics3d::Rc;
 use objects::ball::Ball;
 use objects::box_node::Box;
 use objects::cylinder::Cylinder;
@@ -19,7 +18,7 @@ use objects::plane::Plane;
 use objects::convex::Convex;
 use objects::node::Node;
 
-pub type GraphicsManagerHandle = Rc<RefCell<GraphicsManager>>;
+pub type GraphicsManagerHandle = Rc<GraphicsManager>;
 
 pub struct GraphicsManager {
     rand:             XorShiftRng,
@@ -122,7 +121,7 @@ impl GraphicsManager {
                     }
                     WorldObject::Sensor(ref sensor) => {
                         if let Some(parent) = sensor.borrow().parent() {
-                            let uid = &**parent as *const RefCell<RigidBody<f32>> as usize;
+                            let uid = parent.ptr() as usize;
                             if let Some(pcolor) = self.rb2color.get(&uid) {
                                 color = *pcolor;
                             }

--- a/examples3d/nphysics_testbed3d/src/testbed.rs
+++ b/examples3d/nphysics_testbed3d/src/testbed.rs
@@ -1,6 +1,4 @@
 use std::env;
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::path::Path;
 use time;
 use glfw::{self, MouseButton, Key, Action, WindowEvent};
@@ -18,6 +16,7 @@ use nphysics3d::detection::constraint::Constraint;
 use nphysics3d::detection::joint::{Anchor, Fixed, Joint};
 use nphysics3d::object::{RigidBody, RigidBodyHandle, SensorHandle, WorldObject};
 use nphysics3d::world::World;
+use nphysics3d::Rc;
 use engine::{GraphicsManager, GraphicsManagerHandle};
 
 
@@ -57,7 +56,7 @@ impl Testbed {
         Testbed {
             world:    World::new(),
             window:   window,
-            graphics: Rc::new(RefCell::new(graphics))
+            graphics: Rc::new(graphics)
         }
     }
 
@@ -153,7 +152,7 @@ impl Testbed {
 
         let mut cursor_pos = Point2::new(0.0f32, 0.0);
         let mut grabbed_object: Option<RigidBodyHandle<f32>> = None;
-        let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
+        let mut grabbed_object_joint: Option<Rc<Fixed<f32>>> = None;
         let mut grabbed_object_plane: (Point3<f32>, Vector3<f32>) = (Point3::origin(), na::zero());
 
 

--- a/src/aliases/mod.rs
+++ b/src/aliases/mod.rs
@@ -1,7 +1,5 @@
 //! Aliases for complicated parameterized types.
 
-use std::rc::Rc;
-use std::cell::RefCell;
 use ncollide::bounding_volume::AABB;
 use ncollide::broad_phase::DBVTBroadPhase;
 // use integration::SweptBallMotionClamping;
@@ -9,4 +7,4 @@ use object::RigidBody;
 use math::Point;
 
 /// The type of the broad phase used by the world by default.
-pub type DefaultBroadPhase<N> = DBVTBroadPhase<Point<N>, Rc<RefCell<RigidBody<N>>>, AABB<Point<N>>>;
+pub type DefaultBroadPhase<N> = DBVTBroadPhase<Point<N>, ::Rc<RigidBody<N>>, AABB<Point<N>>>;

--- a/src/detection/constraint.rs
+++ b/src/detection/constraint.rs
@@ -1,8 +1,5 @@
 //! Data structure to describe a constraint between two rigid bodies.
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use alga::general::Real;
 use ncollide::query::Contact;
 use object::RigidBody;
@@ -12,11 +9,11 @@ use math::Point;
 /// A constraint between two rigid bodies.
 pub enum Constraint<N: Real> {
     /// A contact.
-    RBRB(Rc<RefCell<RigidBody<N>>>, Rc<RefCell<RigidBody<N>>>, Contact<Point<N>>),
+    RBRB(::Rc<RigidBody<N>>, ::Rc<RigidBody<N>>, Contact<Point<N>>),
     /// A ball-in-socket joint.
-    BallInSocket(Rc<RefCell<BallInSocket<N>>>),
+    BallInSocket(::Rc<BallInSocket<N>>),
     /// A fixed joint.
-    Fixed(Rc<RefCell<Fixed<N>>>),
+    Fixed(::Rc<Fixed<N>>),
 }
 
 impl<N: Real> Clone for Constraint<N> {

--- a/src/detection/joint/anchor.rs
+++ b/src/detection/joint/anchor.rs
@@ -1,6 +1,3 @@
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use alga::general::Real;
 use na;
 use object::RigidBody;
@@ -9,7 +6,7 @@ use math::Point;
 /// One of the two end points of a joint.
 pub struct Anchor<N: Real, P> {
     /// The body attached to this anchor.
-    pub body:     Option<Rc<RefCell<RigidBody<N>>>>,
+    pub body:     Option<::Rc<RigidBody<N>>>,
     /// The attach position, in local coordinates of the attached body.
     pub position: P
 }
@@ -19,7 +16,7 @@ impl<N: Real, P> Anchor<N, P> {
     ///
     /// If `body` is `None`, the anchor is concidered to be attached to the ground and `position`
     /// is the attach point in global coordinates.
-    pub fn new(body: Option<Rc<RefCell<RigidBody<N>>>>, position: P) -> Anchor<N, P> {
+    pub fn new(body: Option<::Rc<RigidBody<N>>>, position: P) -> Anchor<N, P> {
         Anchor {
             body:     body,
             position: position

--- a/src/integration/translational_ccd_motion_clamping.rs
+++ b/src/integration/translational_ccd_motion_clamping.rs
@@ -1,4 +1,3 @@
-use std::cell::RefCell;
 use na;
 use alga::general::Real;
 use ncollide::utils::data::hash_map::HashMap;
@@ -8,7 +7,7 @@ use ncollide::query;
 use ncollide::bounding_volume;
 use ncollide::world::CollisionGroups;
 use world::RigidBodyCollisionWorld;
-use object::{RigidBodyHandle, SensorHandle, RigidBody};
+use object::{RigidBodyHandle, SensorHandle};
 use math::{Point, Translation};
 
 
@@ -55,13 +54,13 @@ impl<N: Real> TranslationalCCDMotionClamping<N> {
                       rigid_body:       RigidBodyHandle<N>,
                       motion_threshold: N,
                       trigger_sensors:  bool) {
-        let _ = self.objects.insert(&*rigid_body as *const RefCell<RigidBody<N>> as usize,
-                                    CCDRigidBody::new(rigid_body, motion_threshold, trigger_sensors));
+        let _ = self.objects.insert(rigid_body.ptr() as usize,
+                            CCDRigidBody::new(rigid_body, motion_threshold, trigger_sensors));
     }
 
     /// Enables continuous collision for the given rigid body.
     pub fn remove_ccd_from(&mut self, rigid_body: &RigidBodyHandle<N>) {
-        let _ = self.objects.remove(&(&**rigid_body as *const RefCell<RigidBody<N>> as usize));
+        let _ = self.objects.remove(&(rigid_body.ptr() as usize));
     }
 
     /// Update the time of impacts and apply motion clamping when necessary.
@@ -80,7 +79,7 @@ impl<N: Real> TranslationalCCDMotionClamping<N> {
 
             if na::norm_squared(&movement) > co1.value.sqthreshold {
                 // Use CCD for this object.
-                let obj1_uid = &*co1.value.rigid_body as *const RefCell<RigidBody<N>> as usize;
+                let obj1_uid = co1.value.rigid_body.ptr() as usize;
 
                 let last_transform = Translation::from_vector(-movement) * obj1.position();
                 let begin_aabb     = bounding_volume::aabb(obj1.shape().as_ref(), &last_transform);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,6 +116,9 @@ pub mod utils;
 pub mod volumetric;
 // mod tests;
 
+mod rc;
+
+pub use self::rc::{Rc, Ref, RefMut};
 
 /// Compilation flags dependent aliases for mathematical types.
 #[cfg(feature = "dim3")]

--- a/src/object/rigid_body.rs
+++ b/src/object/rigid_body.rs
@@ -1,8 +1,6 @@
 use std::mem;
 use std::any::Any;
 use std::ops::Mul;
-use std::rc::Rc;
-use std::cell::RefCell;
 use num::Bounded;
 
 use alga::general::Real;
@@ -15,7 +13,10 @@ use volumetric::{InertiaTensor, Volumetric};
 use object::RigidBodyCollisionGroups;
 
 /// A shared, mutable, rigid body.
-pub type RigidBodyHandle<N> = Rc<RefCell<RigidBody<N>>>;
+pub type RigidBodyHandle<N> = ::Rc<RigidBody<N>>;
+
+/// User-defined data attached to a `RigidBody`
+pub type UserData = Box<Any + Send + Sync>;
 
 // FIXME: is this still useful (the same information is given by `self.inv_mass.is_zero()` ?
 #[derive(Debug, PartialEq, Clone, RustcEncodable, RustcDecodable)]
@@ -77,7 +78,7 @@ pub struct RigidBody<N: Real> {
     ang_acc_scale:        Orientation<N>, // FIXME: find a better way of doing that.
     margin:               N,
     collision_groups:     RigidBodyCollisionGroups,
-    user_data:            Option<Box<Any>>
+    user_data:            Option<UserData>
 }
 
 impl<N: Real> Clone for RigidBody<N> {
@@ -688,18 +689,18 @@ impl<N: Real> RigidBody<N> {
 
     /// Reference to user-defined data attached to this rigid body.
     #[inline]
-    pub fn user_data(&self) -> Option<&Box<Any>> {
+    pub fn user_data(&self) -> Option<&UserData> {
         self.user_data.as_ref()
     }
 
     /// Mutable reference to user-defined data attached to this rigid body.
     #[inline]
-    pub fn user_data_mut(&mut self) -> Option<&mut Box<Any>> {
+    pub fn user_data_mut(&mut self) -> Option<&mut UserData> {
         self.user_data.as_mut()
     }
 
     /// Attach some user-defined data to this rigid body and return the old one.
-    pub fn set_user_data(&mut self, user_data: Option<Box<Any>>) -> Option<Box<Any>> {
+    pub fn set_user_data(&mut self, user_data: Option<UserData>) -> Option<UserData> {
         mem::replace(&mut self.user_data, user_data)
     }
 }

--- a/src/object/sensor.rs
+++ b/src/object/sensor.rs
@@ -1,7 +1,5 @@
 use std::mem;
 use std::any::Any;
-use std::rc::Rc;
-use std::cell::RefCell;
 
 use alga::general::Real;
 use na;
@@ -10,7 +8,7 @@ use math::{Point, Isometry};
 use object::{RigidBodyHandle, SensorCollisionGroups};
 
 /// A shared, mutable, sensor.
-pub type SensorHandle<N> = Rc<RefCell<Sensor<N>>>;
+pub type SensorHandle<N> = ::Rc<Sensor<N>>;
 
 /// An object capable of detecting interferances with other entities without interacting with them.
 pub struct Sensor<N: Real> {

--- a/src/object/world_object.rs
+++ b/src/object/world_object.rs
@@ -1,5 +1,3 @@
-use std::cell::{RefCell, Ref, RefMut};
-
 use alga::general::Real;
 use ncollide::shape::ShapeHandle;
 use object::{RigidBody, Sensor, RigidBodyHandle, SensorHandle};
@@ -17,17 +15,17 @@ pub enum WorldObject<N: Real> {
 /// Reference to a world object.
 pub enum WorldObjectBorrowed<'a, N: Real> {
     /// A borrowed rigid body handle.
-    RigidBody(Ref<'a, RigidBody<N>>),
+    RigidBody(::Ref<'a, RigidBody<N>>),
     /// A borrowed sensor handle.
-    Sensor(Ref<'a, Sensor<N>>)
+    Sensor(::Ref<'a, Sensor<N>>)
 }
 
 /// Mutable reference to a world object.
 pub enum WorldObjectBorrowedMut<'a, N: Real> {
     /// A mutably borrowed rigid body handle.
-    RigidBody(RefMut<'a, RigidBody<N>>),
+    RigidBody(::RefMut<'a, RigidBody<N>>),
     /// A mutably borrowed sensor handle.
-    Sensor(RefMut<'a, Sensor<N>>)
+    Sensor(::RefMut<'a, Sensor<N>>)
 }
 
 impl<N: Real> WorldObject<N> {
@@ -36,7 +34,7 @@ impl<N: Real> WorldObject<N> {
     /// This identifier remains unique and will not change as long as `rb` is kept alive in memory.
     #[inline]
     pub fn rigid_body_uid(rb: &RigidBodyHandle<N>) -> usize {
-        &**rb as *const RefCell<RigidBody<N>> as usize
+        rb.ptr() as usize
     }
 
     /// The unique identifier a sensor would have if it was wrapped on a `WorldObject`.
@@ -44,7 +42,7 @@ impl<N: Real> WorldObject<N> {
     /// This identifier remains unique and will not change as long as `s` is kept alive in memory.
     #[inline]
     pub fn sensor_uid(s: &SensorHandle<N>) -> usize {
-        &**s  as *const RefCell<Sensor<N>> as usize
+        s.ptr() as usize
     }
 
     /// Whether or not this is a rigid body.
@@ -103,7 +101,7 @@ impl<N: Real> WorldObject<N> {
 
     /// Borrows this world object as a sensor.
     #[inline]
-    pub fn borrow_sensor(&self) -> Ref<Sensor<N>> {
+    pub fn borrow_sensor(&self) -> ::Ref<Sensor<N>> {
         match *self {
             WorldObject::Sensor(ref s) => s.borrow(),
             _                          => panic!("This world object is not a sensor.")
@@ -112,7 +110,7 @@ impl<N: Real> WorldObject<N> {
 
     /// Borrows this world object as a rigid body.
     #[inline]
-    pub fn borrow_rigid_body(&self) -> Ref<RigidBody<N>> {
+    pub fn borrow_rigid_body(&self) -> ::Ref<RigidBody<N>> {
         match *self {
             WorldObject::RigidBody(ref rb) => rb.borrow(),
             _                              => panic!("This world object is not a rigid body.")
@@ -130,7 +128,7 @@ impl<N: Real> WorldObject<N> {
 
     /// Mutably borrows this world object as a sensor.
     #[inline]
-    pub fn borrow_mut_sensor(&mut self) -> RefMut<Sensor<N>> {
+    pub fn borrow_mut_sensor(&mut self) -> ::RefMut<Sensor<N>> {
         match *self {
             WorldObject::Sensor(ref mut s) => s.borrow_mut(),
             _                              => panic!("This world object is not a sensor.")
@@ -139,7 +137,7 @@ impl<N: Real> WorldObject<N> {
 
     /// Mutably borrows this world object as a rigid body.
     #[inline]
-    pub fn borrow_mut_rigid_body(&mut self) -> RefMut<RigidBody<N>> {
+    pub fn borrow_mut_rigid_body(&mut self) -> ::RefMut<RigidBody<N>> {
         match *self {
             WorldObject::RigidBody(ref mut rb) => rb.borrow_mut(),
             _                                  => panic!("This world object is not a rigid body.")

--- a/src/rc/arc.rs
+++ b/src/rc/arc.rs
@@ -1,0 +1,43 @@
+#![allow(missing_docs)]
+
+use std::ops;
+use std::sync::{Arc, RwLock, RwLockReadGuard, RwLockWriteGuard};
+
+type Inner<T> = RwLock<T>;
+
+pub struct Rc<T>(Arc<Inner<T>>);
+
+pub type Ref<'a, T> = RwLockReadGuard<'a, T>;
+pub type RefMut<'a, T> = RwLockWriteGuard<'a, T>;
+
+impl<T> Rc<T> {
+    pub fn new(val: T) -> Self {
+        Rc(Arc::new(RwLock::new(val)))
+    }
+
+    pub fn borrow(&self) -> Ref<T> {
+        self.0.read().expect("Failed to borrow value")
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        self.0.write().expect("Failed to mutably borrow value")
+    }
+
+    pub fn ptr(&self) -> *const Inner<T> {
+        &*self.0 as *const _
+    }
+}
+
+impl<T> Clone for Rc<T> {
+    fn clone(&self) -> Self {
+        Rc(self.0.clone())
+    }
+}
+
+impl<T> ops::Deref for Rc<T> {
+    type Target = Inner<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}

--- a/src/rc/mod.rs
+++ b/src/rc/mod.rs
@@ -1,0 +1,14 @@
+//! Reference-counted type wrapper
+//!
+//! Uses `Rc<RefCell<T>>` internally by default, but uses `Arc<RwLock<T>>` instead if the
+//! `threadsafe` feature is enabled.
+
+#[cfg(not(feature = "threadsafe"))]
+mod rc;
+#[cfg(not(feature = "threadsafe"))]
+pub use self::rc::*;
+
+#[cfg(feature = "threadsafe")]
+mod arc;
+#[cfg(feature = "threadsafe")]
+pub use self::arc::*;

--- a/src/rc/rc.rs
+++ b/src/rc/rc.rs
@@ -1,0 +1,43 @@
+#![allow(missing_docs)]
+
+use std::{self, ops};
+use std::cell::{self, RefCell};
+
+type Inner<T> = RefCell<T>;
+
+pub struct Rc<T>(std::rc::Rc<Inner<T>>);
+
+pub type Ref<'a, T> = cell::Ref<'a, T>;
+pub type RefMut<'a, T> = cell::RefMut<'a, T>;
+
+impl<T> Rc<T> {
+    pub fn new(val: T) -> Self {
+        Rc(std::rc::Rc::new(RefCell::new(val)))
+    }
+
+    pub fn borrow(&self) -> Ref<T> {
+        self.0.borrow()
+    }
+
+    pub fn borrow_mut(&self) -> RefMut<T> {
+        self.0.borrow_mut()
+    }
+
+    pub fn ptr(&self) -> *const Inner<T> {
+        &*self.0 as *const _
+    }
+}
+
+impl<T> Clone for Rc<T> {
+    fn clone(&self) -> Self {
+        Rc(self.0.clone())
+    }
+}
+
+impl<T> ops::Deref for Rc<T> {
+    type Target = Inner<T>;
+
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}

--- a/src/resolution/constraint/accumulated_impulse_solver.rs
+++ b/src/resolution/constraint/accumulated_impulse_solver.rs
@@ -1,5 +1,3 @@
-use std::rc::Rc;
-use std::cell::RefCell;
 use std::iter;
 // use rand::RngUtil;
 use alga::general::Real;
@@ -93,7 +91,7 @@ impl<N: Real> AccumulatedImpulseSolver<N> {
                 dt:          N,
                 constraints: &[Constraint<N>],
                 joints:      &[usize],
-                bodies:      &[Rc<RefCell<RigidBody<N>>>]) {
+                bodies:      &[::Rc<RigidBody<N>>]) {
         let num_friction_equations    = (na::dimension::<Vector<N>>() - 1) * self.cache.len();
         let num_restitution_equations = self.cache.len();
         let mut num_joint_equations = 0;
@@ -273,8 +271,8 @@ impl<N: Real> Solver<N, Constraint<N>> for AccumulatedImpulseSolver<N> {
                 match *cstr {
                     Constraint::RBRB(ref a, ref b, ref c) => {
                         self.cache.insert(i,
-                                          &**a as *const RefCell<RigidBody<N>> as usize,
-                                          &**b as *const RefCell<RigidBody<N>> as usize,
+                                          a.ptr() as usize,
+                                          b.ptr() as usize,
                                           na::center(&c.world1, &c.world2));
                     },
                     Constraint::BallInSocket(_) => {
@@ -335,8 +333,8 @@ impl<N: Real> Solver<N, Constraint<N>> for AccumulatedImpulseSolver<N> {
 
             let mut id = 0;
 
-            fn set_body_index<N: Real>(a:      &Rc<RefCell<RigidBody<N>>>,
-                                       bodies: &mut Vec<Rc<RefCell<RigidBody<N>>>>,
+            fn set_body_index<N: Real>(a:      &::Rc<RigidBody<N>>,
+                                       bodies: &mut Vec<::Rc<RigidBody<N>>>,
                                        id:     &mut isize) {
                 let mut ba = a.borrow_mut();
                 if ba.index() == -2 {

--- a/src/resolution/constraint/ball_in_socket_equation.rs
+++ b/src/resolution/constraint/ball_in_socket_equation.rs
@@ -1,4 +1,3 @@
-use std::cell::Ref;
 use num::Bounded;
 
 use alga::general::Real;
@@ -76,7 +75,7 @@ pub fn cancel_relative_linear_motion<N: Real, P>(
 }
 
 #[inline]
-pub fn write_anchor_id<'a, N: Real, P>(anchor: &'a Anchor<N, P>, id: &mut isize) -> Option<Ref<'a, RigidBody<N>>> {
+pub fn write_anchor_id<'a, N: Real, P>(anchor: &'a Anchor<N, P>, id: &mut isize) -> Option<::Ref<'a, RigidBody<N>>> {
     match anchor.body {
         Some(ref b) => {
             let rb = b.borrow();

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -1,7 +1,5 @@
 use std::slice::Iter;
 use std::iter::Map;
-use std::rc::Rc;
-use std::cell::RefCell;
 
 use alga::general::Real;
 use na;
@@ -47,7 +45,7 @@ pub struct World<N: Real> {
     sensors:      HashMap<usize, SensorHandle<N>, UintTWHash>,
     forces:       BodyForceGenerator<N>,
     integrator:   BodySmpEulerIntegrator,
-    sleep:        Rc<RefCell<ActivationManager<N>>>, // FIXME: avoid sharing (needed for the contact signal handler)
+    sleep:        ::Rc<ActivationManager<N>>, // FIXME: avoid sharing (needed for the contact signal handler)
     ccd:          TranslationalCCDMotionClamping<N>,
     joints:       JointManager<N>,
     solver:       AccumulatedImpulseSolver<N>,
@@ -83,7 +81,7 @@ impl<N: Real> World<N> {
         let ccd = TranslationalCCDMotionClamping::new();
 
         // Deactivation
-        let sleep = Rc::new(RefCell::new(ActivationManager::new(na::convert(0.01f64))));
+        let sleep = ::Rc::new(ActivationManager::new(na::convert(0.01f64)));
 
         // Setup contact handler to reactivate sleeping objects that loose contact.
         let handler = ObjectActivationOnContactHandler { sleep: sleep.clone() };
@@ -184,7 +182,7 @@ impl<N: Real> World<N> {
         let shape = rb.shape().clone();
         let groups = rb.collision_groups().as_collision_groups().clone();
         let collision_object_prediction = rb.margin() + self.prediction / na::convert(2.0f64);
-        let handle = Rc::new(RefCell::new(rb));
+        let handle = ::Rc::new(rb);
         let uid = WorldObject::rigid_body_uid(&handle);
 
         let _ = self.rigid_bodies.insert(uid, handle.clone());
@@ -202,8 +200,8 @@ impl<N: Real> World<N> {
         let shape    = sensor.shape().clone();
         let groups   = sensor.collision_groups().as_collision_groups().clone();
         let margin   = sensor.margin();
-        let handle   = Rc::new(RefCell::new(sensor));
-        let uid      = &*handle as *const RefCell<Sensor<N>> as usize;
+        let handle   = ::Rc::new(sensor);
+        let uid      = handle.ptr() as usize;
 
         let _ = self.sensors.insert(uid, handle.clone());
         self.cworld.deferred_add(uid, position, shape, groups,
@@ -297,8 +295,8 @@ impl<N: Real> World<N> {
     }
 
     /// Adds a ball-in-socket joint to the world.
-    pub fn add_ball_in_socket(&mut self, joint: BallInSocket<N>) -> Rc<RefCell<BallInSocket<N>>> {
-        let res = Rc::new(RefCell::new(joint));
+    pub fn add_ball_in_socket(&mut self, joint: BallInSocket<N>) -> ::Rc<BallInSocket<N>> {
+        let res = ::Rc::new(joint);
 
         self.joints.add_ball_in_socket(res.clone(), &mut *self.sleep.borrow_mut());
 
@@ -306,13 +304,13 @@ impl<N: Real> World<N> {
     }
 
     /// Removes a ball-in-socket joint from the world.
-    pub fn remove_ball_in_socket(&mut self, joint: &Rc<RefCell<BallInSocket<N>>>) {
+    pub fn remove_ball_in_socket(&mut self, joint: &::Rc<BallInSocket<N>>) {
         self.joints.remove_ball_in_socket(joint, &mut *self.sleep.borrow_mut())
     }
 
     /// Adds a fixed joint to the world.
-    pub fn add_fixed(&mut self, joint: Fixed<N>) -> Rc<RefCell<Fixed<N>>> {
-        let res = Rc::new(RefCell::new(joint));
+    pub fn add_fixed(&mut self, joint: Fixed<N>) -> ::Rc<Fixed<N>> {
+        let res = ::Rc::new(joint);
 
         self.joints.add_fixed(res.clone(), &mut *self.sleep.borrow_mut());
 
@@ -320,7 +318,7 @@ impl<N: Real> World<N> {
     }
 
     /// Removes a fixed joint from the world.
-    pub fn remove_fixed(&mut self, joint: &Rc<RefCell<Fixed<N>>>) {
+    pub fn remove_fixed(&mut self, joint: &::Rc<Fixed<N>>) {
         self.joints.remove_joint(joint, &mut *self.sleep.borrow_mut())
     }
 
@@ -402,7 +400,7 @@ impl<N: Real> World<N> {
 }
 
 struct ObjectActivationOnContactHandler<N: Real> {
-    sleep: Rc<RefCell<ActivationManager<N>>>
+    sleep: ::Rc<ActivationManager<N>>
 }
 
 impl<N: Real> ContactHandler<Point<N>, Isometry<N>, WorldObject<N>>


### PR DESCRIPTION
This adds a module that exposes an `Rc<T>` type, that internally uses either `Rc<RefCell<T>>`, or `Arc<RwLock<T>>`, depending on whether the `threadsafe` feature is enabled.

For users, this shouldn't change anything, as the new `Rc` has a `borrow` method just like `RefCell<T>`. It also implements `Deref`, which will return `RefCell<T>`/`RwLock<T>`. Performance will only drop if the user chooses to use threadsafe types.

It may be necessary to add `try_borrow` in addition to `borrow`, especially when `threadsafe` is enabled, as `borrow` will currently panic if it can't get the value. For my use case I haven't run into any problems, but this may not be the case for others. If the changes proposed here look good, I will add `try_borrow` just in case.