### PR TITLE
Fix collection of objects in proximity of a sensor.

### DIFF
--- a/build/nphysics3d/tests/free_sensor_update.rs
+++ b/build/nphysics3d/tests/free_sensor_update.rs
@@ -1,0 +1,28 @@
+extern crate nalgebra as na;
+extern crate ncollide;
+extern crate nphysics3d;
+
+use ncollide::shape::{Ball};
+use nphysics3d::world::World;
+use nphysics3d::object::{RigidBody, Sensor};
+
+#[test]
+fn free_sensor_update() {
+    let mut world = World::new();
+
+    let mut ball = RigidBody::new_dynamic(Ball::new(0.5), 1.0, 0.3, 0.5);
+    ball.set_transformation(na::Isometry3::from_parts(na::Translation3::new(1.0, 1.0, 1.0), na::one()));
+    world.add_rigid_body(ball);
+
+    let mut sensor = Sensor::new(Ball::new(0.1), None);
+    sensor.enable_interfering_bodies_collection();
+    sensor.set_relative_position(na::Isometry3::from_parts(na::Translation3::new(0.0, 0.0, 0.0), na::one()));
+
+    let sensor = world.add_sensor(sensor);
+    world.step(1.0);
+    assert_eq!(sensor.borrow().interfering_bodies().unwrap().len(), 0);
+
+    sensor.borrow_mut().set_relative_position(na::Isometry3::from_parts(na::Translation3::new(1.0, 1.0, 1.0), na::one()));
+    world.step(1.0);
+    assert_eq!(sensor.borrow().interfering_bodies().unwrap().len(), 1);
+}

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,7 +1,7 @@
 //! Objects that may be added to the physical world.
 
 pub use self::rigid_body::{RigidBody, RigidBodyHandle, ActivationState, RigidBodyState};
-pub use self::sensor::{Sensor, SensorHandle};
+pub use self::sensor::{Sensor, SensorHandle, SensorProximityCollector};
 pub use self::world_object::{WorldObject, WorldObjectBorrowed, WorldObjectBorrowedMut};
 pub use self::rigid_body_collision_groups::RigidBodyCollisionGroups;
 pub use self::sensor_collision_groups::SensorCollisionGroups;

--- a/src/object/sensor.rs
+++ b/src/object/sensor.rs
@@ -27,7 +27,9 @@ pub struct Sensor<N: Real> {
     parent_prox:         bool,
     user_data:           Option<Box<Any>>,
     interfering_bodies:  Option<HashMap<usize, RigidBodyHandle<N>, UintTWHash>>,
-    interfering_sensors: Option<HashMap<usize, SensorHandle<N>, UintTWHash>>
+    interfering_sensors: Option<HashMap<usize, SensorHandle<N>, UintTWHash>>,
+    #[doc(hidden)]
+    pub did_move_locally:    bool
 }
 
 impl<N: Real> Sensor<N> {
@@ -51,6 +53,7 @@ impl<N: Real> Sensor<N> {
         Sensor {
             parent:              parent,
             relative_position:   na::one(),
+            did_move_locally:    true,
             shape:               shape,
             margin:              na::zero(),
             collision_groups:    SensorCollisionGroups::new(),
@@ -145,6 +148,7 @@ impl<N: Real> Sensor<N> {
     /// If `self.parent()` is `None`, then this sets the sensor's absolute position.
     #[inline]
     pub fn set_relative_position(&mut self, rel_pos: Isometry<N>) {
+        self.did_move_locally  = true;
         self.relative_position = rel_pos
     }
 
@@ -163,6 +167,7 @@ impl<N: Real> Sensor<N> {
     /// position and updates it.
     #[inline]
     pub fn set_position(&mut self, abs_pos: Isometry<N>) {
+        self.did_move_locally = true;
         match self.parent {
             Some(ref rb) => {
                 self.relative_position = rb.borrow().position().inverse() * abs_pos

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,6 +1,6 @@
 //! The physics world.
 
-pub use world::world::{World, WorldBroadPhase, RigidBodies, RigidBodyCollisionWorld,
+pub use world::world::{World, WorldBroadPhase, RigidBodies, Sensors, RigidBodyCollisionWorld,
                        WorldCollisionObject};
 
 mod world;

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -19,7 +19,7 @@ use detection::ActivationManager;
 use detection::constraint::Constraint;
 use detection::joint::{JointManager, BallInSocket, Fixed};
 use resolution::{Solver, AccumulatedImpulseSolver, CorrectionMode};
-use object::{WorldObject, RigidBody, RigidBodyHandle, Sensor, SensorHandle};
+use object::{WorldObject, RigidBody, RigidBodyHandle, Sensor, SensorHandle, SensorProximityCollector};
 use math::{Point, Vector, Isometry};
 
 /// The default broad phase.
@@ -94,6 +94,11 @@ impl<N: Real> World<N> {
         let filter      = SensorsNotCollidingTheirParentPairFilter;
         let filter_name = "__nphysics_internal_SensorsNotCollidingTheirParentPairFilter";
         cworld.register_broad_phase_pair_filter(filter_name, filter);
+
+        // Setup the proximity collector for sensors.
+        let collector      = SensorProximityCollector;
+        let collector_name = "__nphysics_internal_SensorProximityCollector";
+        cworld.register_proximity_handler(collector_name, collector);
 
         // Joints
         let joints = JointManager::new();

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -141,11 +141,17 @@ impl<N: Real> World<N> {
         }
 
         for e in self.sensors.elements_mut().iter_mut() {
-            let sensor = e.value.borrow_mut();
+            let mut sensor = e.value.borrow_mut();
 
-            if let Some(rb) = sensor.parent() {
-                if rb.borrow().is_active() {
-                    self.cworld.deferred_set_position(WorldObject::sensor_uid(&e.value), sensor.position());
+            if sensor.did_move_locally {
+                sensor.did_move_locally = false;
+                self.cworld.deferred_set_position(WorldObject::sensor_uid(&e.value), sensor.position());
+            }
+            else {
+                if let Some(rb) = sensor.parent() {
+                    if rb.borrow().is_active() {
+                        self.cworld.deferred_set_position(WorldObject::sensor_uid(&e.value), sensor.position());
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix #87.

The collection has to be explicitly enabled for each sensor calling `.enable_interfering_bodies_collection` and `.enable_interfering_sensors_collection`.