### PR TITLE
fix travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 sudo: false
+dist: trusty
 language: rust
 rust:
     - stable
@@ -6,7 +7,7 @@ rust:
     - nightly
 matrix:
   allow_failures:
-    - rust: beta 
+    - rust: beta
     - rust: nightly
 addons:
   apt:
@@ -18,6 +19,7 @@ addons:
       - libglew-dev
       - libopenal-dev
       - libsndfile1-dev
+      - xorg-dev
 cache:
   apt: true
   directories:


### PR DESCRIPTION
set travis dist to trusty to update cmake
because error was: `CMake 2.8.12 or higher is required.  You are running version 2.8.11.2`

also add xorg-dev for glfw in travis (this may be cause by the distro change)

if you have other repo with ci that fails tell me