### PR TITLE
impl send sync to world to use it with specs

### DIFF
--- a/build/nphysics3d/Cargo.toml
+++ b/build/nphysics3d/Cargo.toml
@@ -23,7 +23,8 @@ rustc-serialize = "0.3"
 num-traits = "0.1"
 alga       = "0.5"
 nalgebra   = "0.13"
-ncollide   = "0.13"
+ncollide   = { git = "https://github.com/thiolliere/ncollide/", branch = "send_sync_master" }
 
 [dev-dependencies]
 approx     = "0.1"
+

--- a/build/nphysics3d/tests/free_sensor_update.rs
+++ b/build/nphysics3d/tests/free_sensor_update.rs
@@ -20,9 +20,9 @@ fn free_sensor_update() {
 
     let sensor = world.add_sensor(sensor);
     world.step(1.0);
-    assert_eq!(sensor.borrow().interfering_bodies().unwrap().len(), 0);
+    assert_eq!(world.sensor(sensor).interfering_bodies().unwrap().len(), 0);
 
-    sensor.borrow_mut().set_relative_position(na::Isometry3::from_parts(na::Translation3::new(1.0, 1.0, 1.0), na::one()));
+    world.mut_sensor(sensor).set_relative_position(na::Isometry3::from_parts(na::Translation3::new(1.0, 1.0, 1.0), na::one()));
     world.step(1.0);
-    assert_eq!(sensor.borrow().interfering_bodies().unwrap().len(), 1);
+    assert_eq!(world.sensor(sensor).interfering_bodies().unwrap().len(), 1);
 }

--- a/examples3d/nphysics_testbed3d/src/engine.rs
+++ b/examples3d/nphysics_testbed3d/src/engine.rs
@@ -9,7 +9,7 @@ use kiss3d::scene::SceneNode;
 use kiss3d::camera::{Camera, ArcBall, FirstPerson};
 use ncollide::shape::{Shape3, Plane3, Ball3, Cuboid3, Cylinder3, Cone3, Compound3, TriMesh3, ConvexHull3};
 use ncollide::transformation;
-use nphysics3d::object::{RigidBody, WorldObject, WorldObjectBorrowed, RigidBodyHandle, SensorHandle};
+use nphysics3d::object::{RigidBody, WorldObject};
 use objects::ball::Ball;
 use objects::box_node::Box;
 use objects::cylinder::Cylinder;
@@ -69,7 +69,7 @@ impl GraphicsManager {
         self.aabbs.clear();
     }
 
-    pub fn remove(&mut self, window: &mut Window, object: &WorldObject<f32>) {
+    pub fn remove(&mut self, window: &mut Window, object: &WorldObject) {
         let key = object.uid();
 
         match self.rb2sn.get(&key) {
@@ -84,58 +84,61 @@ impl GraphicsManager {
         self.rb2sn.remove(&key);
     }
 
-    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
-        let key = WorldObject::rigid_body_uid(rb);
+    // TODO
+    // pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
+    //     let key = WorldObject::rigid_body_uid(rb);
 
-        self.rb2color.insert(key, color);
+    //     self.rb2color.insert(key, color);
 
-        if let Some(ns) = self.rb2sn.get_mut(&key) {
-            for n in ns.iter_mut() {
-                n.set_color(color)
-            }
-        }
+    //     if let Some(ns) = self.rb2sn.get_mut(&key) {
+    //         for n in ns.iter_mut() {
+    //             n.set_color(color)
+    //         }
+    //     }
+    // }
+
+    // TODO
+    // pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
+    //     let key = WorldObject::sensor_uid(sensor);
+
+    //     self.rb2color.insert(key, color);
+
+    //     if let Some(ns) = self.rb2sn.get_mut(&key) {
+    //         for n in ns.iter_mut() {
+    //             n.set_color(color)
+    //         }
+    //     }
+    // }
+
+    pub fn add(&mut self, window: &mut Window, object: WorldObject) {
+        unimplemented!();
+        // let mut color = Point3::new(0.5, 0.5, 0.5);
+
+        // match self.rb2color.get(&object.uid()) {
+        //     Some(c) => color = *c,
+        //     None    => {
+        //         match object {
+        //             WorldObject::RigidBody(ref rb) => {
+        //                 if rb.borrow().can_move() {
+        //                     color = self.rand.gen();
+        //                 }
+        //             }
+        //             WorldObject::Sensor(ref sensor) => {
+        //                 if let Some(parent) = sensor.borrow().parent() {
+        //                     let uid = &**parent as *const RefCell<RigidBody<f32>> as usize;
+        //                     if let Some(pcolor) = self.rb2color.get(&uid) {
+        //                         color = *pcolor;
+        //                     }
+        //                 }
+        //             }
+        //         }
+        //     }
+        // }
+
+        // self.add_with_color(window, object, color)
     }
 
-    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
-        let key = WorldObject::sensor_uid(sensor);
-
-        self.rb2color.insert(key, color);
-
-        if let Some(ns) = self.rb2sn.get_mut(&key) {
-            for n in ns.iter_mut() {
-                n.set_color(color)
-            }
-        }
-    }
-
-    pub fn add(&mut self, window: &mut Window, object: WorldObject<f32>) {
-        let mut color = Point3::new(0.5, 0.5, 0.5);
-
-        match self.rb2color.get(&object.uid()) {
-            Some(c) => color = *c,
-            None    => {
-                match object {
-                    WorldObject::RigidBody(ref rb) => {
-                        if rb.borrow().can_move() {
-                            color = self.rand.gen();
-                        }
-                    }
-                    WorldObject::Sensor(ref sensor) => {
-                        if let Some(parent) = sensor.borrow().parent() {
-                            let uid = &**parent as *const RefCell<RigidBody<f32>> as usize;
-                            if let Some(pcolor) = self.rb2color.get(&uid) {
-                                color = *pcolor;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
-        self.add_with_color(window, object, color)
-    }
-
-    pub fn add_with_color(&mut self, window: &mut Window, object: WorldObject<f32>, color: Point3<f32>) {
+    pub fn add_with_color(&mut self, window: &mut Window, object: WorldObject, color: Point3<f32>) {
         let nodes = {
             let mut nodes = Vec::new();
 
@@ -158,7 +161,7 @@ impl GraphicsManager {
 
     fn add_shape(&mut self,
                 window: &mut Window,
-                object: WorldObject<f32>,
+                object: WorldObject,
                 delta:  Isometry3<f32>,
                 shape:  &Shape3<f32>,
                 color:  Point3<f32>,
@@ -197,7 +200,7 @@ impl GraphicsManager {
 
     fn add_plane(&mut self,
                  window: &mut Window,
-                 object: WorldObject<f32>,
+                 object: WorldObject,
                  shape:  &Plane3<f32>,
                  color:  Point3<f32>,
                  out:    &mut Vec<Node>) {
@@ -209,7 +212,7 @@ impl GraphicsManager {
 
     fn add_mesh(&mut self,
                 window: &mut Window,
-                object: WorldObject<f32>,
+                object: WorldObject,
                 delta:  Isometry3<f32>,
                 shape:   &TriMesh3<f32>,
                 color:  Point3<f32>,
@@ -224,7 +227,7 @@ impl GraphicsManager {
 
     fn add_ball(&mut self,
                 window: &mut Window,
-                object: WorldObject<f32>,
+                object: WorldObject,
                 delta:  Isometry3<f32>,
                 shape:   &Ball3<f32>,
                 color:  Point3<f32>,
@@ -235,7 +238,7 @@ impl GraphicsManager {
 
     fn add_box(&mut self,
                window: &mut Window,
-               object: WorldObject<f32>,
+               object: WorldObject,
                delta:  Isometry3<f32>,
                shape:  &Cuboid3<f32>,
                color:  Point3<f32>,
@@ -249,7 +252,7 @@ impl GraphicsManager {
 
     fn add_convex(&mut self,
                   window: &mut Window,
-                  object: WorldObject<f32>,
+                  object: WorldObject,
                   delta:  Isometry3<f32>,
                   shape:  &ConvexHull3<f32>,
                   color:  Point3<f32>,
@@ -259,7 +262,7 @@ impl GraphicsManager {
 
     fn add_cylinder(&mut self,
                     window: &mut Window,
-                    object: WorldObject<f32>,
+                    object: WorldObject,
                     delta:  Isometry3<f32>,
                     shape:   &Cylinder3<f32>,
                     color:  Point3<f32>,
@@ -272,7 +275,7 @@ impl GraphicsManager {
 
     fn add_cone(&mut self,
                 window: &mut Window,
-                object: WorldObject<f32>,
+                object: WorldObject,
                 delta:  Isometry3<f32>,
                 shape:  &Cone3<f32>,
                 color:  Point3<f32>,
@@ -292,25 +295,26 @@ impl GraphicsManager {
     }
 
     pub fn draw_positions(&mut self, window: &mut Window) {
-        for (_, ns) in self.rb2sn.iter_mut() {
-            for n in ns.iter_mut() {
-                let object = n.object().borrow();
+        unimplemented!();
+        // for (_, ns) in self.rb2sn.iter_mut() {
+        //     for n in ns.iter_mut() {
+        //         let object = n.object().borrow();
 
-                if let WorldObjectBorrowed::RigidBody(rb) = object {
-                    let t      = rb.position();
-                    let center = rb.center_of_mass();
+        //         if let WorldObjectBorrowed::RigidBody(rb) = object {
+        //             let t      = rb.position();
+        //             let center = rb.center_of_mass();
 
-                    let rotmat = t.rotation.to_rotation_matrix().unwrap();
-                    let x = rotmat.column(0) * 0.25f32;
-                    let y = rotmat.column(1) * 0.25f32;
-                    let z = rotmat.column(2) * 0.25f32;
+        //             let rotmat = t.rotation.to_rotation_matrix().unwrap();
+        //             let x = rotmat.column(0) * 0.25f32;
+        //             let y = rotmat.column(1) * 0.25f32;
+        //             let z = rotmat.column(2) * 0.25f32;
 
-                    window.draw_line(center, &(*center + x), &Point3::new(1.0, 0.0, 0.0));
-                    window.draw_line(center, &(*center + y), &Point3::new(0.0, 1.0, 0.0));
-                    window.draw_line(center, &(*center + z), &Point3::new(0.0, 0.0, 1.0));
-                }
-            }
-        }
+        //             window.draw_line(center, &(*center + x), &Point3::new(1.0, 0.0, 0.0));
+        //             window.draw_line(center, &(*center + y), &Point3::new(0.0, 1.0, 0.0));
+        //             window.draw_line(center, &(*center + z), &Point3::new(0.0, 0.0, 1.0));
+        //         }
+        //     }
+        // }
     }
 
     pub fn switch_cameras(&mut self) {
@@ -347,19 +351,23 @@ impl GraphicsManager {
         self.first_person.look_at(eye, at);
     }
 
-    pub fn rigid_body_nodes(&self, rb: &RigidBodyHandle<f32>) -> Option<&Vec<Node>> {
-        self.rb2sn.get(&WorldObject::rigid_body_uid(rb))
-    }
+    // TODO
+    // pub fn rigid_body_nodes(&self, rb: &RigidBodyHandle<f32>) -> Option<&Vec<Node>> {
+    //     self.rb2sn.get(&WorldObject::rigid_body_uid(rb))
+    // }
 
-    pub fn sensor_nodes(&self, sensor: &SensorHandle<f32>) -> Option<&Vec<Node>> {
-        self.rb2sn.get(&WorldObject::sensor_uid(sensor))
-    }
+    // TODO
+    // pub fn sensor_nodes(&self, sensor: &SensorHandle<f32>) -> Option<&Vec<Node>> {
+    //     self.rb2sn.get(&WorldObject::sensor_uid(sensor))
+    // }
 
-    pub fn rigid_body_nodes_mut(&mut self, rb: &RigidBodyHandle<f32>) -> Option<&mut Vec<Node>> {
-        self.rb2sn.get_mut(&WorldObject::rigid_body_uid(rb))
-    }
+    // TODO
+    // pub fn rigid_body_nodes_mut(&mut self, rb: &RigidBodyHandle<f32>) -> Option<&mut Vec<Node>> {
+    //     self.rb2sn.get_mut(&WorldObject::rigid_body_uid(rb))
+    // }
 
-    pub fn sensor_nodes_mut(&mut self, sensor: &SensorHandle<f32>) -> Option<&mut Vec<Node>> {
-        self.rb2sn.get_mut(&WorldObject::sensor_uid(sensor))
-    }
+    // TODO
+    // pub fn sensor_nodes_mut(&mut self, sensor: &SensorHandle<f32>) -> Option<&mut Vec<Node>> {
+    //     self.rb2sn.get_mut(&WorldObject::sensor_uid(sensor))
+    // }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/ball.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/ball.rs
@@ -9,11 +9,11 @@ pub struct Ball {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>
+    body:       WorldObject,
 }
 
 impl Ball {
-    pub fn new(body:   WorldObject<f32>,
+    pub fn new(body:   WorldObject,
                delta:  Isometry3<f32>,
                radius: f32,
                color:  Point3<f32>,
@@ -67,7 +67,7 @@ impl Ball {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/box_node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/box_node.rs
@@ -9,11 +9,11 @@ pub struct Box {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>,
+    body:       WorldObject,
 }
 
 impl Box {
-    pub fn new(body:   WorldObject<f32>,
+    pub fn new(body:   WorldObject,
                delta:  Isometry3<f32>,
                rx:     f32,
                ry:     f32,
@@ -72,7 +72,7 @@ impl Box {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cone.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cone.rs
@@ -9,11 +9,11 @@ pub struct Cone {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>,
+    body:       WorldObject,
 }
 
 impl Cone {
-    pub fn new(body:   WorldObject<f32>,
+    pub fn new(body:   WorldObject,
                delta:  Isometry3<f32>,
                r:      f32,
                h:      f32,
@@ -68,7 +68,7 @@ impl Cone {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/convex.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/convex.rs
@@ -10,11 +10,11 @@ pub struct Convex {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>
+    body:       WorldObject
 }
 
 impl Convex {
-    pub fn new(body:   WorldObject<f32>,
+    pub fn new(body:   WorldObject,
                delta:  Isometry3<f32>,
                convex: &TriMesh<Point3<f32>>,
                color:  Point3<f32>,
@@ -69,7 +69,7 @@ impl Convex {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/cylinder.rs
@@ -9,11 +9,11 @@ pub struct Cylinder {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>,
+    body:       WorldObject,
 }
 
 impl Cylinder {
-    pub fn new(body:   WorldObject<f32>,
+    pub fn new(body:   WorldObject,
                delta:  Isometry3<f32>,
                r:      f32,
                h:      f32,
@@ -67,7 +67,7 @@ impl Cylinder {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/mesh.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/mesh.rs
@@ -12,11 +12,11 @@ pub struct Mesh {
     base_color: Point3<f32>,
     delta:      Isometry3<f32>,
     gfx:        SceneNode,
-    body:       WorldObject<f32>
+    body:       WorldObject
 }
 
 impl Mesh {
-    pub fn new(body:     WorldObject<f32>,
+    pub fn new(body:     WorldObject,
                delta:    Isometry3<f32>,
                vertices: Vec<Point3<f32>>,
                indices:  Vec<Point3<u32>>,
@@ -76,7 +76,7 @@ impl Mesh {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/node.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/node.rs
@@ -1,6 +1,6 @@
 use kiss3d::scene::SceneNode;
 use na::{Isometry3, Point3};
-use nphysics3d::object::{WorldObject, WorldObjectBorrowed};
+use nphysics3d::object::WorldObject;
 use objects::ball::Ball;
 use objects::box_node::Box;
 use objects::cylinder::Cylinder;
@@ -80,7 +80,7 @@ impl Node {
         }
     }
 
-    pub fn object<'a>(&'a self) -> &'a WorldObject<f32> {
+    pub fn object<'a>(&'a self) -> &'a WorldObject {
         match *self {
             Node::Plane(ref n)    => n.object(),
             Node::Ball(ref n)     => n.object(),
@@ -107,27 +107,28 @@ impl Node {
 
 
 pub fn update_scene_node(node:   &mut SceneNode,
-                         object: &WorldObject<f32>,
+                         object: &WorldObject,
                          color:  &Point3<f32>,
                          delta:  &Isometry3<f32>) {
-    let rb = object.borrow();
+    unimplemented!();
+    // let rb = object.borrow();
 
-    match rb {
-        WorldObjectBorrowed::RigidBody(rb) => {
-            if rb.is_active() {
-                node.set_local_transformation(*rb.position() * *delta);
-                node.set_color(color.x, color.y, color.z);
-            }
-            else {
-                node.set_color(color.x * 0.25, color.y * 0.25, color.z * 0.25);
-            }
-        },
-        WorldObjectBorrowed::Sensor(s) => {
-            if let Some(rb) = s.parent() {
-                if rb.borrow().is_active() {
-                    node.set_local_transformation(s.position() * *delta);
-                }
-            }
-        }
-    }
+    // match rb {
+    //     WorldObjectBorrowed::RigidBody(rb) => {
+    //         if rb.is_active() {
+    //             node.set_local_transformation(*rb.position() * *delta);
+    //             node.set_color(color.x, color.y, color.z);
+    //         }
+    //         else {
+    //             node.set_color(color.x * 0.25, color.y * 0.25, color.z * 0.25);
+    //         }
+    //     },
+    //     WorldObjectBorrowed::Sensor(s) => {
+    //         if let Some(rb) = s.parent() {
+    //             if rb.borrow().is_active() {
+    //                 node.set_local_transformation(s.position() * *delta);
+    //             }
+    //         }
+    //     }
+    // }
 }

--- a/examples3d/nphysics_testbed3d/src/objects/plane.rs
+++ b/examples3d/nphysics_testbed3d/src/objects/plane.rs
@@ -6,11 +6,11 @@ use nphysics3d::object::WorldObject;
 
 pub struct Plane {
     gfx:  SceneNode,
-    body: WorldObject<f32>
+    body: WorldObject
 }
 
 impl Plane {
-    pub fn new(body:         WorldObject<f32>,
+    pub fn new(body:         WorldObject,
                world_pos:    &Point3<f32>,
                world_normal: &Vector3<f32>,
                color:        Point3<f32>,
@@ -67,7 +67,7 @@ impl Plane {
         &mut self.gfx
     }
 
-    pub fn object(&self) -> &WorldObject<f32> {
+    pub fn object(&self) -> &WorldObject {
         &self.body
     }
 }

--- a/examples3d/nphysics_testbed3d/src/testbed.rs
+++ b/examples3d/nphysics_testbed3d/src/testbed.rs
@@ -16,7 +16,7 @@ use ncollide::query::{self, Ray};
 use ncollide::world::CollisionGroups;
 use nphysics3d::detection::constraint::Constraint;
 use nphysics3d::detection::joint::{Anchor, Fixed, Joint};
-use nphysics3d::object::{RigidBody, RigidBodyHandle, SensorHandle, WorldObject};
+use nphysics3d::object::{RigidBody, WorldObject};
 use nphysics3d::world::World;
 use engine::{GraphicsManager, GraphicsManagerHandle};
 
@@ -61,39 +61,45 @@ impl Testbed {
         }
     }
 
-    pub fn new(world: World<f32>) -> Testbed {
-        let mut res = Testbed::new_empty();
+    // TODO
+    // pub fn new(world: World<f32>) -> Testbed {
+    //     let mut res = Testbed::new_empty();
 
-        res.set_world(world);
+    //     res.set_world(world);
 
-        res
-    }
+    //     res
+    // }
 
-    pub fn set_world(&mut self, world: World<f32>) {
-        self.world = world;
+    // TODO
+    // pub fn set_world(&mut self, world: World<f32>) {
+    //     self.world = world;
 
-        self.graphics.borrow_mut().clear(&mut self.window);
+    //     self.graphics.borrow_mut().clear(&mut self.window);
 
-        for rb in self.world.rigid_bodies() {
-            self.graphics.borrow_mut().add(&mut self.window, WorldObject::RigidBody(rb.clone()));
-        }
+    //     for rb in self.world.rigid_bodies() {
+    //         self.graphics.borrow_mut().add(&mut self.window, WorldObject::RigidBody(rb.clone()));
+    //     }
 
-        for sensor in self.world.sensors() {
-            self.graphics.borrow_mut().add(&mut self.window, WorldObject::Sensor(sensor.clone()));
-        }
-    }
+    //     for sensor in self.world.sensors() {
+    //         self.graphics.borrow_mut().add(&mut self.window, WorldObject::Sensor(sensor.clone()));
+    //     }
+    // }
 
     pub fn look_at(&mut self, eye: Point3<f32>, at: Point3<f32>) {
         self.graphics.borrow_mut().look_at(eye, at);
     }
 
-    pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
-        self.graphics.borrow_mut().set_rigid_body_color(rb, color);
-    }
+    // TODO
+    // pub fn set_rigid_body_color(&mut self, rb: &RigidBodyHandle<f32>, color: Point3<f32>) {
+    //     unimplemented!();
+    //     // self.graphics.borrow_mut().set_rigid_body_color(rb, color);
+    // }
 
-    pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
-        self.graphics.borrow_mut().set_sensor_color(sensor, color);
-    }
+    // TODO
+    // pub fn set_sensor_color(&mut self, sensor: &SensorHandle<f32>, color: Point3<f32>) {
+    //     unimplemented!();
+    //     // self.graphics.borrow_mut().set_sensor_color(sensor, color);
+    // }
 
     pub fn world(&self) -> &World<f32> {
         &self.world
@@ -131,318 +137,319 @@ impl Testbed {
     }
 
     pub fn run(&mut self) {
-        let mut args    = env::args();
-        let mut running = RunMode::Running;
+        unimplemented!();
+        // let mut args    = env::args();
+        // let mut running = RunMode::Running;
 
-        if args.len() > 1 {
-            let exname = args.next().unwrap();
-            for arg in args {
-                if &arg[..] == "--help" || &arg[..] == "-h" {
-                    usage(&exname[..]);
-                    return;
-                }
-                else if &arg[..] == "--pause" {
-                    running = RunMode::Stop;
-                }
-            }
-        }
+        // if args.len() > 1 {
+        //     let exname = args.next().unwrap();
+        //     for arg in args {
+        //         if &arg[..] == "--help" || &arg[..] == "-h" {
+        //             usage(&exname[..]);
+        //             return;
+        //         }
+        //         else if &arg[..] == "--pause" {
+        //             running = RunMode::Stop;
+        //         }
+        //     }
+        // }
 
-        let font_mem       = include_bytes!("Inconsolata.otf");
-        let font           = Font::from_memory(font_mem, 60);
-        let mut draw_colls = false;
+        // let font_mem       = include_bytes!("Inconsolata.otf");
+        // let font           = Font::from_memory(font_mem, 60);
+        // let mut draw_colls = false;
 
-        let mut cursor_pos = Point2::new(0.0f32, 0.0);
-        let mut grabbed_object: Option<RigidBodyHandle<f32>> = None;
-        let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
-        let mut grabbed_object_plane: (Point3<f32>, Vector3<f32>) = (Point3::origin(), na::zero());
+        // let mut cursor_pos = Point2::new(0.0f32, 0.0);
+        // let mut grabbed_object: Option<RigidBodyHandle<f32>> = None;
+        // let mut grabbed_object_joint: Option<Rc<RefCell<Fixed<f32>>>> = None;
+        // let mut grabbed_object_plane: (Point3<f32>, Vector3<f32>) = (Point3::origin(), na::zero());
 
 
-        self.window.set_framerate_limit(Some(60));
-        self.window.set_light(Light::StickToCamera);
+        // self.window.set_framerate_limit(Some(60));
+        // self.window.set_light(Light::StickToCamera);
 
-        while !self.window.should_close() {
-            for mut event in self.window.events().iter() {
-                match event.value {
-                    WindowEvent::MouseButton(MouseButton::Button2, Action::Press, glfw::Control) => {
-                        let mut graphics = self.graphics.borrow_mut();
-                        let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5f32, 0.5f32));
-                        let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
+        // while !self.window.should_close() {
+        //     for mut event in self.window.events().iter() {
+        //         match event.value {
+        //             WindowEvent::MouseButton(MouseButton::Button2, Action::Press, glfw::Control) => {
+        //                 let mut graphics = self.graphics.borrow_mut();
+        //                 let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5f32, 0.5f32));
+        //                 let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
-                        let size = self.window.size();
-                        let (pos, dir) = graphics.camera().unproject(&cursor_pos, &size);
+        //                 let size = self.window.size();
+        //                 let (pos, dir) = graphics.camera().unproject(&cursor_pos, &size);
 
-                        rb.set_translation(Translation3::from_vector(pos.coords));
-                        rb.set_lin_vel(dir * 1000.0f32);
+        //                 rb.set_translation(Translation3::from_vector(pos.coords));
+        //                 rb.set_lin_vel(dir * 1000.0f32);
 
-                        let body = self.world.add_rigid_body(rb);
-                        self.world.add_ccd_to(&body, 1.0, false);
-                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
-                    },
-                    WindowEvent::MouseButton(MouseButton::Button1, Action::Press, modifier) => {
-                        if modifier.contains(glfw::Shift) {
-                            // XXX: huge and uggly code duplication
-                            let size = self.window.size();
-                            let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
-                            let ray = Ray::new(pos, dir);
+        //                 let body = self.world.add_rigid_body(rb);
+        //                 self.world.add_ccd_to(&body, 1.0, false);
+        //                 graphics.add(&mut self.window, WorldObject::RigidBody(body));
+        //             },
+        //             WindowEvent::MouseButton(MouseButton::Button1, Action::Press, modifier) => {
+        //                 if modifier.contains(glfw::Shift) {
+        //                     // XXX: huge and uggly code duplication
+        //                     let size = self.window.size();
+        //                     let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
+        //                     let ray = Ray::new(pos, dir);
 
-                            // cast the ray
-                            let mut mintoi = Bounded::max_value();
-                            let mut minb   = None;
+        //                     // cast the ray
+        //                     let mut mintoi = Bounded::max_value();
+        //                     let mut minb   = None;
 
-                            let all_groups = &CollisionGroups::new();
-                            // FIXME: add the Sensor group to the blacklist so that they are not
-                            // reported for ray-casting.
-                            for (b, inter) in self.world
-                                                  .collision_world()
-                                                  .interferences_with_ray(&ray, all_groups) {
-                                if  inter.toi < mintoi {
-                                    if let &WorldObject::RigidBody(ref rb) = &b.data {
-                                        mintoi = inter.toi;
-                                        minb   = Some(rb.clone());
-                                    }
-                                }
-                            }
+        //                     let all_groups = &CollisionGroups::new();
+        //                     // FIXME: add the Sensor group to the blacklist so that they are not
+        //                     // reported for ray-casting.
+        //                     for (b, inter) in self.world
+        //                                           .collision_world()
+        //                                           .interferences_with_ray(&ray, all_groups) {
+        //                         if  inter.toi < mintoi {
+        //                             if let &WorldObject::RigidBody(ref rb) = &b.data {
+        //                                 mintoi = inter.toi;
+        //                                 minb   = Some(rb.clone());
+        //                             }
+        //                         }
+        //                     }
 
-                            if minb.is_some() {
-                                let b = minb.as_ref().unwrap();
-                                if b.borrow().can_move() {
-                                    self.world.remove_rigid_body(b);
-                                    self.graphics.borrow_mut().remove(&mut self.window, &WorldObject::RigidBody(b.clone()));
-                                }
-                            }
+        //                     if minb.is_some() {
+        //                         let b = minb.as_ref().unwrap();
+        //                         if b.borrow().can_move() {
+        //                             self.world.remove_rigid_body(b);
+        //                             self.graphics.borrow_mut().remove(&mut self.window, &WorldObject::RigidBody(b.clone()));
+        //                         }
+        //                     }
 
-                            event.inhibited = true;
-                        }
-                        else if modifier.contains(glfw::Control) {
-                            match grabbed_object {
-                                Some(ref rb) => {
-                                    for n in self.graphics.borrow_mut().rigid_body_nodes_mut(rb).unwrap().iter_mut() {
-                                        n.unselect()
-                                    }
-                                },
-                                None => { }
-                            }
+        //                     event.inhibited = true;
+        //                 }
+        //                 else if modifier.contains(glfw::Control) {
+        //                     match grabbed_object {
+        //                         Some(ref rb) => {
+        //                             for n in self.graphics.borrow_mut().rigid_body_nodes_mut(rb).unwrap().iter_mut() {
+        //                                 n.unselect()
+        //                             }
+        //                         },
+        //                         None => { }
+        //                     }
 
-                            // XXX: huge and uggly code duplication
-                            let size = self.window.size();
-                            let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
-                            let ray = Ray::new(pos, dir);
+        //                     // XXX: huge and uggly code duplication
+        //                     let size = self.window.size();
+        //                     let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
+        //                     let ray = Ray::new(pos, dir);
 
-                            // cast the ray
-                            let mut mintoi = Bounded::max_value();
-                            let mut minb   = None;
+        //                     // cast the ray
+        //                     let mut mintoi = Bounded::max_value();
+        //                     let mut minb   = None;
 
-                            let all_groups = CollisionGroups::new();
-                            for (b, inter) in self.world
-                                                  .collision_world()
-                                                  .interferences_with_ray(&ray, &all_groups) {
-                                if  inter.toi < mintoi {
-                                    if let &WorldObject::RigidBody(ref rb) = &b.data {
-                                        mintoi = inter.toi;
-                                        minb   = Some(rb.clone());
-                                    }
-                                }
-                            }
+        //                     let all_groups = CollisionGroups::new();
+        //                     for (b, inter) in self.world
+        //                                           .collision_world()
+        //                                           .interferences_with_ray(&ray, &all_groups) {
+        //                         if  inter.toi < mintoi {
+        //                             if let &WorldObject::RigidBody(ref rb) = &b.data {
+        //                                 mintoi = inter.toi;
+        //                                 minb   = Some(rb.clone());
+        //                             }
+        //                         }
+        //                     }
 
-                            if minb.is_some() {
-                                let b = minb.as_ref().unwrap();
-                                if b.borrow().can_move() {
-                                    grabbed_object = Some(b.clone())
-                                }
-                            }
+        //                     if minb.is_some() {
+        //                         let b = minb.as_ref().unwrap();
+        //                         if b.borrow().can_move() {
+        //                             grabbed_object = Some(b.clone())
+        //                         }
+        //                     }
 
-                            match grabbed_object {
-                                Some(ref b) => {
-                                    for n in self.graphics.borrow_mut().rigid_body_nodes_mut(b).unwrap().iter_mut() {
-                                        match grabbed_object_joint {
-                                            Some(ref j) => self.world.remove_fixed(j),
-                                            None        => { }
-                                        }
+        //                     match grabbed_object {
+        //                         Some(ref b) => {
+        //                             for n in self.graphics.borrow_mut().rigid_body_nodes_mut(b).unwrap().iter_mut() {
+        //                                 match grabbed_object_joint {
+        //                                     Some(ref j) => self.world.remove_fixed(j),
+        //                                     None        => { }
+        //                                 }
 
-                                        let attach2_pos = ray.origin + ray.dir * mintoi;
-                                        let attach2 = Isometry3::new(attach2_pos.coords, na::zero());
-                                        let attach1 = b.borrow().position().inverse() * attach2;
+        //                                 let attach2_pos = ray.origin + ray.dir * mintoi;
+        //                                 let attach2 = Isometry3::new(attach2_pos.coords, na::zero());
+        //                                 let attach1 = b.borrow().position().inverse() * attach2;
 
-                                        let anchor1 = Anchor::new(Some(minb.as_ref().unwrap().clone()), attach1);
-                                        let anchor2 = Anchor::new(None, attach2);
-                                        let joint   = Fixed::new(anchor1, anchor2);
-                                        grabbed_object_plane = (attach2_pos, -ray.dir);
-                                        grabbed_object_joint = Some(self.world.add_fixed(joint));
-                                        // Add a joint.
-                                        n.select()
-                                    }
-                                },
-                                None => { }
-                            }
+        //                                 let anchor1 = Anchor::new(Some(minb.as_ref().unwrap().clone()), attach1);
+        //                                 let anchor2 = Anchor::new(None, attach2);
+        //                                 let joint   = Fixed::new(anchor1, anchor2);
+        //                                 grabbed_object_plane = (attach2_pos, -ray.dir);
+        //                                 grabbed_object_joint = Some(self.world.add_fixed(joint));
+        //                                 // Add a joint.
+        //                                 n.select()
+        //                             }
+        //                         },
+        //                         None => { }
+        //                     }
 
-                            event.inhibited = true;
-                        }
-                    },
-                    WindowEvent::MouseButton(_, Action::Release, _) => {
-                        let mut graphics = self.graphics.borrow_mut();
-                        match grabbed_object {
-                            Some(ref b) => {
-                                for n in graphics.rigid_body_nodes_mut(b).unwrap().iter_mut() {
-                                    n.unselect()
-                                }
-                            },
-                            None => { }
-                        }
+        //                     event.inhibited = true;
+        //                 }
+        //             },
+        //             WindowEvent::MouseButton(_, Action::Release, _) => {
+        //                 let mut graphics = self.graphics.borrow_mut();
+        //                 match grabbed_object {
+        //                     Some(ref b) => {
+        //                         for n in graphics.rigid_body_nodes_mut(b).unwrap().iter_mut() {
+        //                             n.unselect()
+        //                         }
+        //                     },
+        //                     None => { }
+        //                 }
 
-                        match grabbed_object_joint {
-                            Some(ref j) => self.world.remove_fixed(j),
-                            None    => { }
-                        }
+        //                 match grabbed_object_joint {
+        //                     Some(ref j) => self.world.remove_fixed(j),
+        //                     None    => { }
+        //                 }
 
-                        grabbed_object       = None;
-                        grabbed_object_joint = None;
-                    },
-                    WindowEvent::CursorPos(x, y) => {
-                        cursor_pos.x = x as f32;
-                        cursor_pos.y = y as f32;
+        //                 grabbed_object       = None;
+        //                 grabbed_object_joint = None;
+        //             },
+        //             WindowEvent::CursorPos(x, y) => {
+        //                 cursor_pos.x = x as f32;
+        //                 cursor_pos.y = y as f32;
 
-                        // update the joint
-                        match grabbed_object_joint {
-                            Some(ref j) => {
-                                let size = self.window.size();
-                                let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
-                                let (ref ppos, ref pdir) = grabbed_object_plane;
+        //                 // update the joint
+        //                 match grabbed_object_joint {
+        //                     Some(ref j) => {
+        //                         let size = self.window.size();
+        //                         let (pos, dir) = self.graphics.borrow().camera().unproject(&cursor_pos, &size);
+        //                         let (ref ppos, ref pdir) = grabbed_object_plane;
 
-                                match query::ray_internal::plane_toi_with_ray(ppos, pdir, &Ray::new(pos, dir)) {
-                                    Some(inter) => {
-                                        j.borrow_mut().set_local2(Isometry3::new((pos + dir * inter).coords, na::zero()))
-                                    },
-                                    None => { }
-                                }
+        //                         match query::ray_internal::plane_toi_with_ray(ppos, pdir, &Ray::new(pos, dir)) {
+        //                             Some(inter) => {
+        //                                 j.borrow_mut().set_local2(Isometry3::new((pos + dir * inter).coords, na::zero()))
+        //                             },
+        //                             None => { }
+        //                         }
 
-                            },
-                            None => { }
-                        }
+        //                     },
+        //                     None => { }
+        //                 }
 
-                        event.inhibited =
-                            self.window.glfw_window().get_key(Key::RightShift)   != Action::Release ||
-                            self.window.glfw_window().get_key(Key::LeftShift)    != Action::Release ||
-                            self.window.glfw_window().get_key(Key::RightControl) != Action::Release ||
-                            self.window.glfw_window().get_key(Key::LeftControl)  != Action::Release;
-                    },
-                    WindowEvent::Key(Key::Tab, _, Action::Release, _) => self.graphics.borrow_mut().switch_cameras(),
-                    WindowEvent::Key(Key::T, _,   Action::Release, _) => {
-                        if running == RunMode::Stop {
-                            running = RunMode::Running;
-                        }
-                        else {
-                            running = RunMode::Stop;
-                        }
-                    },
-                    WindowEvent::Key(Key::S, _, Action::Release, _) => running = RunMode::Step,
-                    WindowEvent::Key(Key::B, _, Action::Release, _) => {
-                        // XXX: there is a bug on kiss3d with the removal of objects.
-                        // draw_aabbs = !draw_aabbs;
-                        // if draw_aabbs {
-                        //     graphics.enable_aabb_draw(&mut self.window);
-                        // }
-                        // else {
-                        //     graphics.disable_aabb_draw(&mut self.window);
-                        // }
-                    },
-                    WindowEvent::Key(Key::Space, _, Action::Release, _) => {
-                        let mut graphics = self.graphics.borrow_mut();
-                        draw_colls = !draw_colls;
-                        for rb in self.world.rigid_bodies() {
-                            // FIXME: ugly clone.
-                            if let Some(ns) = graphics.rigid_body_nodes_mut(rb) {
-                                for n in ns.iter_mut() {
-                                    if draw_colls {
-                                        n.scene_node_mut().set_lines_width(1.0);
-                                        n.scene_node_mut().set_surface_rendering_activation(false);
-                                    }
-                                    else {
-                                        n.scene_node_mut().set_lines_width(0.0);
-                                        n.scene_node_mut().set_surface_rendering_activation(true);
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    WindowEvent::Key(Key::Num1, _, Action::Press, _) => {
-                        let mut graphics = self.graphics.borrow_mut();
-                        let geom   = Ball::new(0.5f32);
-                        let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
+        //                 event.inhibited =
+        //                     self.window.glfw_window().get_key(Key::RightShift)   != Action::Release ||
+        //                     self.window.glfw_window().get_key(Key::LeftShift)    != Action::Release ||
+        //                     self.window.glfw_window().get_key(Key::RightControl) != Action::Release ||
+        //                     self.window.glfw_window().get_key(Key::LeftControl)  != Action::Release;
+        //             },
+        //             WindowEvent::Key(Key::Tab, _, Action::Release, _) => self.graphics.borrow_mut().switch_cameras(),
+        //             WindowEvent::Key(Key::T, _,   Action::Release, _) => {
+        //                 if running == RunMode::Stop {
+        //                     running = RunMode::Running;
+        //                 }
+        //                 else {
+        //                     running = RunMode::Stop;
+        //                 }
+        //             },
+        //             WindowEvent::Key(Key::S, _, Action::Release, _) => running = RunMode::Step,
+        //             WindowEvent::Key(Key::B, _, Action::Release, _) => {
+        //                 // XXX: there is a bug on kiss3d with the removal of objects.
+        //                 // draw_aabbs = !draw_aabbs;
+        //                 // if draw_aabbs {
+        //                 //     graphics.enable_aabb_draw(&mut self.window);
+        //                 // }
+        //                 // else {
+        //                 //     graphics.disable_aabb_draw(&mut self.window);
+        //                 // }
+        //             },
+        //             WindowEvent::Key(Key::Space, _, Action::Release, _) => {
+        //                 let mut graphics = self.graphics.borrow_mut();
+        //                 draw_colls = !draw_colls;
+        //                 for rb in self.world.rigid_bodies() {
+        //                     // FIXME: ugly clone.
+        //                     if let Some(ns) = graphics.rigid_body_nodes_mut(rb) {
+        //                         for n in ns.iter_mut() {
+        //                             if draw_colls {
+        //                                 n.scene_node_mut().set_lines_width(1.0);
+        //                                 n.scene_node_mut().set_surface_rendering_activation(false);
+        //                             }
+        //                             else {
+        //                                 n.scene_node_mut().set_lines_width(0.0);
+        //                                 n.scene_node_mut().set_surface_rendering_activation(true);
+        //                             }
+        //                         }
+        //                     }
+        //                 }
+        //             },
+        //             WindowEvent::Key(Key::Num1, _, Action::Press, _) => {
+        //                 let mut graphics = self.graphics.borrow_mut();
+        //                 let geom   = Ball::new(0.5f32);
+        //                 let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
-                        let cam_transfom;
+        //                 let cam_transfom;
 
-                        {
-                            let cam      = graphics.camera();
-                            cam_transfom = cam.view_transform().inverse()
-                        }
+        //                 {
+        //                     let cam      = graphics.camera();
+        //                     cam_transfom = cam.view_transform().inverse()
+        //                 }
 
-                        rb.append_translation(&cam_transfom.translation);
+        //                 rb.append_translation(&cam_transfom.translation);
 
-                        let front = -cam_transfom.rotation * Vector3::z();
+        //                 let front = -cam_transfom.rotation * Vector3::z();
 
-                        rb.set_lin_vel(front * 40.0f32);
+        //                 rb.set_lin_vel(front * 40.0f32);
 
-                        let body = self.world.add_rigid_body(rb);
-                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
-                    },
-                    WindowEvent::Key(Key::Num2, _, Action::Press, _) => {
-                        let mut graphics = self.graphics.borrow_mut();
-                        let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5, 0.5));
-                        let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
+        //                 let body = self.world.add_rigid_body(rb);
+        //                 graphics.add(&mut self.window, WorldObject::RigidBody(body));
+        //             },
+        //             WindowEvent::Key(Key::Num2, _, Action::Press, _) => {
+        //                 let mut graphics = self.graphics.borrow_mut();
+        //                 let geom   = Cuboid::new(Vector3::new(0.5f32, 0.5, 0.5));
+        //                 let mut rb = RigidBody::new_dynamic(geom, 4.0f32, 0.3, 0.6);
 
-                        let cam_transform;
+        //                 let cam_transform;
 
-                        {
-                            let cam = graphics.camera();
-                            cam_transform = cam.view_transform().inverse()
-                        }
+        //                 {
+        //                     let cam = graphics.camera();
+        //                     cam_transform = cam.view_transform().inverse()
+        //                 }
 
-                        rb.append_translation(&cam_transform.translation);
+        //                 rb.append_translation(&cam_transform.translation);
 
-                        let front = -cam_transform.rotation * Vector3::z();
+        //                 let front = -cam_transform.rotation * Vector3::z();
 
-                        rb.set_lin_vel(front * 40.0f32);
+        //                 rb.set_lin_vel(front * 40.0f32);
 
-                        let body = self.world.add_rigid_body(rb);
-                        graphics.add(&mut self.window, WorldObject::RigidBody(body));
-                    }
-                    _ => { }
-                }
-            }
+        //                 let body = self.world.add_rigid_body(rb);
+        //                 graphics.add(&mut self.window, WorldObject::RigidBody(body));
+        //             }
+        //             _ => { }
+        //         }
+        //     }
 
-            let dt;
+        //     let dt;
 
-            if running != RunMode::Stop {
-                let before = time::precise_time_s();
-                self.world.step(0.016);
-                dt = time::precise_time_s() - before;
+        //     if running != RunMode::Stop {
+        //         let before = time::precise_time_s();
+        //         self.world.step(0.016);
+        //         dt = time::precise_time_s() - before;
 
-                self.graphics.borrow_mut().draw();
-            }
-            else {
-                dt = 0.0;
-            }
+        //         self.graphics.borrow_mut().draw();
+        //     }
+        //     else {
+        //         dt = 0.0;
+        //     }
 
-            if running == RunMode::Step {
-                running = RunMode::Stop;
-            }
+        //     if running == RunMode::Step {
+        //         running = RunMode::Stop;
+        //     }
 
-            if draw_colls {
-                self.graphics.borrow_mut().draw_positions(&mut self.window);
-                draw_collisions(&mut self.window, &mut self.world);
-            }
+        //     if draw_colls {
+        //         self.graphics.borrow_mut().draw_positions(&mut self.window);
+        //         draw_collisions(&mut self.window, &mut self.world);
+        //     }
 
-            let color = Point3::new(1.0, 1.0, 1.0);
+        //     let color = Point3::new(1.0, 1.0, 1.0);
 
-            if running != RunMode::Stop {
-                self.window.draw_text(&format!("Time: {:.*}sec.", 4, dt)[..], &Point2::origin(), &font, &color);
-            }
-            else {
-                self.window.draw_text("Paused", &Point2::origin(), &font, &color);
-            }
+        //     if running != RunMode::Stop {
+        //         self.window.draw_text(&format!("Time: {:.*}sec.", 4, dt)[..], &Point2::origin(), &font, &color);
+        //     }
+        //     else {
+        //         self.window.draw_text("Paused", &Point2::origin(), &font, &color);
+        //     }
 
-            self.window.render_with_camera(self.graphics.borrow_mut().camera_mut());
-        }
+        //     self.window.render_with_camera(self.graphics.borrow_mut().camera_mut());
+        // }
     }
 }
 

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -144,9 +144,8 @@ impl<N: Real> ActivationManager<N> {
          * Body activation/deactivation.
          */
         // Find deactivable islands.
-        for i in 0usize .. self.ufind.len() {
+        for (i, b) in bodies.iter().enumerate() {
             let root = union_find::find(i, &mut self.ufind[..]);
-            let b    = &bodies[i];
 
             self.can_deactivate[root] =
                 match b.deactivation_threshold() {
@@ -158,9 +157,8 @@ impl<N: Real> ActivationManager<N> {
         }
 
         // Activate/deactivate islands.
-        for i in 0usize .. self.ufind.len() {
+        for (i, b) in bodies.iter_mut().enumerate() {
             let root = union_find::find(i, &mut self.ufind[..]);
-            let b = &mut bodies[i];
 
             if self.can_deactivate[root] { // Everybody in this set can be deactivacted.
                 b.deactivate();

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -97,15 +97,8 @@ impl<N: Real> ActivationManager<N> {
          *
          */
         // Resize buffers.
-        if bodies.len() > self.ufind.len() {
-            let to_add = bodies.len() - self.ufind.len();
-            self.ufind.extend(iter::repeat(UnionFindSet::new(0)).take(to_add));
-            self.can_deactivate.extend(iter::repeat(false).take(to_add));
-        }
-        else {
-            self.ufind.truncate(bodies.len());
-            self.can_deactivate.truncate(bodies.len());
-        }
+        self.ufind.resize(bodies.len(), UnionFindSet::new(0));
+        self.can_deactivate.resize(bodies.len(), false);
 
         // Init the union find.
         for (i, u) in self.ufind.iter_mut().enumerate() {

--- a/src/detection/activation_manager.rs
+++ b/src/detection/activation_manager.rs
@@ -1,12 +1,10 @@
 use std::iter;
 use na;
 use alga::general::Real;
-use ncollide::utils::data::hash_map::HashMap;
-use ncollide::utils::data::hash::UintTWHash;
-use world::RigidBodyCollisionWorld;
+use world::{RigidBodyCollisionWorld, RigidBodyStorage};
 use detection::constraint::Constraint;
 use detection::joint::{JointManager, Joint};
-use object::{WorldObject, RigidBody, RigidBodyHandle, ActivationState};
+use object::{WorldObject, RigidBody, ActivationState};
 use utils::union_find::UnionFindSet;
 use utils::union_find;
 
@@ -17,7 +15,7 @@ pub struct ActivationManager<N: Real> {
     mix_factor:     N,
     ufind:          Vec<UnionFindSet>,
     can_deactivate: Vec<bool>,
-    to_activate:    Vec<RigidBodyHandle<N>>,
+    to_activate:    Vec<usize>,
 }
 
 impl<N: Real> ActivationManager<N> {
@@ -39,9 +37,9 @@ impl<N: Real> ActivationManager<N> {
 
     /// Notify the `ActivationManager` that is has to activate an object at the next update.
     // FIXME: this is not a very good name
-    pub fn deferred_activate(&mut self, b: &RigidBodyHandle<N>) {
-        if b.borrow().can_move() && !b.borrow().is_active() {
-            self.to_activate.push(b.clone());
+    pub fn deferred_activate(&mut self, b: &RigidBody<N>) {
+        if b.can_move() && !b.is_active() {
+            self.to_activate.push(b.uid());
         }
     }
 
@@ -63,18 +61,16 @@ impl<N: Real> ActivationManager<N> {
     pub fn update(&mut self,
                   world:  &mut RigidBodyCollisionWorld<N>,
                   joints: &JointManager<N>,
-                  bodies: &HashMap<usize, RigidBodyHandle<N>, UintTWHash>) {
+                  bodies: &mut RigidBodyStorage<N>) {
         /*
          *
          * Update bodies energy
          *
          */
-        for (i, b) in bodies.elements().iter().enumerate() {
-            let mut b = b.value.borrow_mut();
-
+        for (i, b) in bodies.iter_mut().enumerate() {
             assert!(*b.activation_state() != ActivationState::Deleted);
             if b.is_active() {
-                self.update_energy(&mut *b);
+                self.update_energy(b);
             }
 
             b.set_index(i as isize);
@@ -85,12 +81,11 @@ impl<N: Real> ActivationManager<N> {
          * Activate bodies that need it.
          *
          */
-        for b in self.to_activate.iter() {
-            let mut rb = b.borrow_mut();
+        for &b in &self.to_activate {
+            let rb = &mut bodies[b];
 
-            match rb.deactivation_threshold() {
-                Some(threshold) => rb.activate(threshold * na::convert(2.0f64)),
-                None => { }
+            if let Some(threshold) = rb.deactivation_threshold() {
+                rb.activate(threshold * na::convert(2.0f64));
             }
         }
 
@@ -122,38 +117,33 @@ impl<N: Real> ActivationManager<N> {
         }
 
         // Run the union-find.
-        fn make_union<N: Real>(b1: &RigidBodyHandle<N>, b2: &RigidBodyHandle<N>, ufs: &mut [UnionFindSet]) {
-            let rb1 = b1.borrow();
-            let rb2 = b2.borrow();
-
+        fn make_union<N: Real>(rb1: &RigidBody<N>, rb2: &RigidBody<N>, ufs: &mut [UnionFindSet]) {
             if rb1.can_move() && rb2.can_move() {
                 union_find::union(rb1.index() as usize, rb2.index() as usize, ufs)
             }
         }
 
         for (b1, b2, cd) in world.contact_pairs() {
-            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
+            if let (&WorldObject::RigidBody(rb1), &WorldObject::RigidBody(rb2)) = (&b1.data, &b2.data) {
                 if cd.num_contacts() != 0 {
-                    make_union(&rb1, &rb2, &mut self.ufind[..])
+                    make_union(&bodies[rb1], &bodies[rb2], &mut self.ufind[..])
                 }
             }
         }
 
-        for e in joints.joints().elements().iter() {
-            match e.value {
-                Constraint::RBRB(ref b1, ref b2, _) => make_union(b1, b2, &mut self.ufind[..]),
+        for e in joints.joints().iter() {
+            match *e {
+                Constraint::RBRB(b1, b2, _) => make_union(&bodies[b1], &bodies[b2], &mut self.ufind[..]),
                 Constraint::BallInSocket(ref b)   => {
-                    match (b.borrow().anchor1().body.as_ref(), b.borrow().anchor2().body.as_ref()) {
-                        (Some(b1), Some(b2)) => make_union(b1, b2, &mut self.ufind[..]),
-                        _ => { }
+                    if let (Some(b1), Some(b2)) = (b.anchor1().body, b.anchor2().body) {
+                        make_union(&bodies[b1], &bodies[b2], &mut self.ufind[..]);
                     }
                 },
                 Constraint::Fixed(ref f)   => {
-                    match (f.borrow().anchor1().body.as_ref(), f.borrow().anchor2().body.as_ref()) {
-                        (Some(b1), Some(b2)) => make_union(b1, b2, &mut self.ufind[..]),
-                        _ => { }
+                    if let (Some(b1), Some(b2)) = (f.anchor1().body, f.anchor2().body) {
+                        make_union(&bodies[b1], &bodies[b2], &mut self.ufind[..]);
                     }
-                }
+                },
             }
         }
 
@@ -163,7 +153,7 @@ impl<N: Real> ActivationManager<N> {
         // Find deactivable islands.
         for i in 0usize .. self.ufind.len() {
             let root = union_find::find(i, &mut self.ufind[..]);
-            let b    = bodies.elements()[i].value.borrow();
+            let b    = &bodies[i];
 
             self.can_deactivate[root] =
                 match b.deactivation_threshold() {
@@ -177,7 +167,7 @@ impl<N: Real> ActivationManager<N> {
         // Activate/deactivate islands.
         for i in 0usize .. self.ufind.len() {
             let root = union_find::find(i, &mut self.ufind[..]);
-            let mut b = bodies.elements()[i].value.borrow_mut();
+            let b = &mut bodies[i];
 
             if self.can_deactivate[root] { // Everybody in this set can be deactivacted.
                 b.deactivate();

--- a/src/detection/constraint.rs
+++ b/src/detection/constraint.rs
@@ -1,30 +1,17 @@
 //! Data structure to describe a constraint between two rigid bodies.
 
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use alga::general::Real;
 use ncollide::query::Contact;
-use object::RigidBody;
 use detection::joint::{Fixed, BallInSocket};
 use math::Point;
 
 /// A constraint between two rigid bodies.
+#[derive(Clone)]
 pub enum Constraint<N: Real> {
     /// A contact.
-    RBRB(Rc<RefCell<RigidBody<N>>>, Rc<RefCell<RigidBody<N>>>, Contact<Point<N>>),
+    RBRB(usize, usize, Contact<Point<N>>),
     /// A ball-in-socket joint.
-    BallInSocket(Rc<RefCell<BallInSocket<N>>>),
+    BallInSocket(BallInSocket<N>),
     /// A fixed joint.
-    Fixed(Rc<RefCell<Fixed<N>>>),
-}
-
-impl<N: Real> Clone for Constraint<N> {
-    fn clone(&self) -> Constraint<N> {
-        match *self {
-            Constraint::RBRB(ref a, ref b, ref c) => Constraint::RBRB(a.clone(), b.clone(), c.clone()),
-            Constraint::BallInSocket(ref bis)     => Constraint::BallInSocket(bis.clone()),
-            Constraint::Fixed(ref f)              => Constraint::Fixed(f.clone()),
-        }
-    }
+    Fixed(Fixed<N>),
 }

--- a/src/detection/joint/anchor.rs
+++ b/src/detection/joint/anchor.rs
@@ -1,25 +1,23 @@
-use std::rc::Rc;
-use std::cell::RefCell;
-
 use alga::general::Real;
 use na;
-use object::RigidBody;
-use math::Point;
+use world::RigidBodyStorage;
+use math::{Point, Isometry};
 
 /// One of the two end points of a joint.
-pub struct Anchor<N: Real, P> {
+#[derive(Clone)]
+pub struct Anchor<P> {
     /// The body attached to this anchor.
-    pub body:     Option<Rc<RefCell<RigidBody<N>>>>,
+    pub body:     Option<usize>,
     /// The attach position, in local coordinates of the attached body.
     pub position: P
 }
 
-impl<N: Real, P> Anchor<N, P> {
+impl<P> Anchor<P> {
     /// Creates a new `Anchor` at a given `position` on a `body` local space.
     ///
     /// If `body` is `None`, the anchor is concidered to be attached to the ground and `position`
     /// is the attach point in global coordinates.
-    pub fn new(body: Option<Rc<RefCell<RigidBody<N>>>>, position: P) -> Anchor<N, P> {
+    pub fn new(body: Option<usize>, position: P) -> Anchor<P> {
         Anchor {
             body:     body,
             position: position
@@ -27,18 +25,40 @@ impl<N: Real, P> Anchor<N, P> {
     }
 }
 
-impl<N: Real, P> Anchor<N, P> {
+impl<P> Anchor<P> {
     /// The center of mass of the body attached to this anchor.
     ///
     /// Returns the zero vector if no body is attached.
-    pub fn center_of_mass(&self) -> Point<N> {
-        match self.body {
-            Some(ref b) => {
-                let rb = b.borrow();
+    pub fn center_of_mass<N: Real>(&self, bodies: &RigidBodyStorage<N>) -> Point<N> {
+        if let Some(b) = self.body {
+            bodies[b].center_of_mass().clone()
+        } else {
+            na::origin()
+        }
+    }
+}
 
-                rb.center_of_mass().clone()
-            },
-            None => na::origin()
+impl<N: Real> Anchor<Point<N>> {
+    /// The attach point in global coordinates.
+    // TODO: inline ??
+    #[inline]
+    pub fn pos(&self, bodies: &RigidBodyStorage<N>) -> Point<N> {
+        if let Some(b) = self.body {
+            bodies[b].position() * self.position
+        } else {
+            self.position.clone()
+        }
+    }
+}
+
+impl<N: Real> Anchor<Isometry<N>> {
+    /// The attach point in global coordinates.
+    #[inline]
+    pub fn pos(&self, bodies: &RigidBodyStorage<N>) -> Isometry<N> {
+        if let Some(b) = self.body {
+            bodies[b].position() * self.position
+        } else {
+            self.position.clone()
         }
     }
 }

--- a/src/detection/joint/ball_in_socket.rs
+++ b/src/detection/joint/ball_in_socket.rs
@@ -6,15 +6,16 @@ use detection::joint::joint::Joint;
 /// A ball-in-socket joint.
 ///
 /// This is usually used to create ragdolls.
+#[derive(Clone)]
 pub struct BallInSocket<N: Real> {
     up_to_date: bool,
-    anchor1:    Anchor<N, Point<N>>,
-    anchor2:    Anchor<N, Point<N>>,
+    anchor1:    Anchor<Point<N>>,
+    anchor2:    Anchor<Point<N>>,
 }
 
 impl<N: Real> BallInSocket<N> {
     /// Creates a ball-in-socket joint.
-    pub fn new(anchor1: Anchor<N, Point<N>>, anchor2: Anchor<N, Point<N>>) -> BallInSocket<N> {
+    pub fn new(anchor1: Anchor<Point<N>>, anchor2: Anchor<Point<N>>) -> BallInSocket<N> {
         BallInSocket {
             up_to_date: false,
             anchor1:    anchor1,
@@ -54,38 +55,16 @@ impl<N: Real> BallInSocket<N> {
 }
 
 
-impl<N: Real> Joint<N, Point<N>> for BallInSocket<N> {
+impl<N: Real> Joint<Point<N>> for BallInSocket<N> {
     /// The first anchor affected by this joint.
     #[inline]
-    fn anchor1(&self) -> &Anchor<N, Point<N>> {
+    fn anchor1(&self) -> &Anchor<Point<N>> {
         &self.anchor1
     }
 
     /// The second anchor affected by this joint.
     #[inline]
-    fn anchor2(&self) -> &Anchor<N, Point<N>> {
+    fn anchor2(&self) -> &Anchor<Point<N>> {
         &self.anchor2
-    }
-
-    /// The first attach point in global coordinates.
-    #[inline]
-    fn anchor1_pos(&self) -> Point<N> {
-        match self.anchor1.body {
-            Some(ref b) => {
-                b.borrow().position() * self.anchor1.position
-            },
-            None => self.anchor1.position.clone()
-        }
-    }
-
-    /// The second attach point in global coordinates.
-    #[inline]
-    fn anchor2_pos(&self) -> Point<N> {
-        match self.anchor2.body {
-            Some(ref b) => {
-                b.borrow().position() * self.anchor2.position
-            },
-            None => self.anchor2.position.clone()
-        }
     }
 }

--- a/src/detection/joint/fixed.rs
+++ b/src/detection/joint/fixed.rs
@@ -4,15 +4,16 @@ use detection::joint::anchor::Anchor;
 use detection::joint::joint::Joint;
 
 /// A joint that prevents any relative movement (linear and angular) between two objects.
+#[derive(Clone)]
 pub struct Fixed<N: Real> {
     up_to_date: bool,
-    anchor1:    Anchor<N, Isometry<N>>,
-    anchor2:    Anchor<N, Isometry<N>>,
+    anchor1:    Anchor<Isometry<N>>,
+    anchor2:    Anchor<Isometry<N>>,
 }
 
 impl<N: Real> Fixed<N> {
     /// Creates a new `Fixed` joint.
-    pub fn new(anchor1: Anchor<N, Isometry<N>>, anchor2: Anchor<N, Isometry<N>>) -> Fixed<N> {
+    pub fn new(anchor1: Anchor<Isometry<N>>, anchor2: Anchor<Isometry<N>>) -> Fixed<N> {
         Fixed {
             up_to_date: false,
             anchor1:    anchor1,
@@ -51,38 +52,16 @@ impl<N: Real> Fixed<N> {
     }
 }
 
-impl<N: Real> Joint<N, Isometry<N>> for Fixed<N> {
+impl<N: Real> Joint<Isometry<N>> for Fixed<N> {
     /// The first anchor affected by this joint.
     #[inline]
-    fn anchor1(&self) -> &Anchor<N, Isometry<N>> {
+    fn anchor1(&self) -> &Anchor<Isometry<N>> {
         &self.anchor1
     }
 
     /// The second anchor affected by this joint.
     #[inline]
-    fn anchor2(&self) -> &Anchor<N, Isometry<N>> {
+    fn anchor2(&self) -> &Anchor<Isometry<N>> {
         &self.anchor2
-    }
-
-    /// The first attach point in global coordinates.
-    #[inline]
-    fn anchor1_pos(&self) -> Isometry<N> {
-        match self.anchor1.body {
-            Some(ref b) => {
-                *b.borrow().position() * self.anchor1.position
-            },
-            None => self.anchor1.position.clone()
-        }
-    }
-
-    /// The second attach point in global coordinates.
-    #[inline]
-    fn anchor2_pos(&self) -> Isometry<N> {
-        match self.anchor2.body {
-            Some(ref b) => {
-                *b.borrow().position() * self.anchor2.position
-            },
-            None => self.anchor2.position.clone()
-        }
     }
 }

--- a/src/detection/joint/joint.rs
+++ b/src/detection/joint/joint.rs
@@ -1,15 +1,10 @@
-use alga::general::Real;
 use detection::joint::anchor::Anchor;
 
 // FIXME: this wont be very helpful to mix several joints.
 /// Trait implemented by every joint.
-pub trait Joint<N: Real, A> {
+pub trait Joint<A> {
     /// The first anchor affected by this joint.
-    fn anchor1(&self) -> &Anchor<N, A>;
+    fn anchor1(&self) -> &Anchor<A>;
     /// The second anchor affected by this joint.
-    fn anchor2(&self) -> &Anchor<N, A>;
-    /// The first attach point in global coordinates.
-    fn anchor1_pos(&self) -> A;
-    /// The second attach point in global coordinates.
-    fn anchor2_pos(&self) -> A;
+    fn anchor2(&self) -> &Anchor<A>;
 }

--- a/src/object/mod.rs
+++ b/src/object/mod.rs
@@ -1,8 +1,8 @@
 //! Objects that may be added to the physical world.
 
-pub use self::rigid_body::{RigidBody, RigidBodyHandle, ActivationState, RigidBodyState};
-pub use self::sensor::{Sensor, SensorHandle, SensorProximityCollector};
-pub use self::world_object::{WorldObject, WorldObjectBorrowed, WorldObjectBorrowedMut};
+pub use self::rigid_body::{RigidBody, ActivationState, RigidBodyState};
+pub use self::sensor::{Sensor, sensor_handle_proximity};
+pub use self::world_object::WorldObject;
 pub use self::rigid_body_collision_groups::RigidBodyCollisionGroups;
 pub use self::sensor_collision_groups::SensorCollisionGroups;
 pub use self::collision_groups_wrapper_impl::{STATIC_GROUP_ID, SENSOR_GROUP_ID};

--- a/src/object/storage.rs
+++ b/src/object/storage.rs
@@ -1,0 +1,6 @@
+pub trait Storage<B> {
+    type Index: Clone + ::std::hash::Hash + Eq;
+
+    fn get(&self, index: &Self::Index) -> &B;
+    fn get_mut(&mut self, index: &Self::Index) -> &mut B;
+}

--- a/src/object/world_object.rs
+++ b/src/object/world_object.rs
@@ -1,52 +1,13 @@
-use std::cell::{RefCell, Ref, RefMut};
-
-use alga::general::Real;
-use ncollide::shape::ShapeHandle;
-use object::{RigidBody, Sensor, RigidBodyHandle, SensorHandle};
-use math::{Isometry, Point};
-
 /// An object that has been added to a World.
 #[derive(Clone)]
-pub enum WorldObject<N: Real> {
+pub enum WorldObject {
     /// A rigid body handle.
-    RigidBody(RigidBodyHandle<N>),
+    RigidBody(usize),
     /// A sensor handle.
-    Sensor(SensorHandle<N>)
+    Sensor(usize)
 }
 
-/// Reference to a world object.
-pub enum WorldObjectBorrowed<'a, N: Real> {
-    /// A borrowed rigid body handle.
-    RigidBody(Ref<'a, RigidBody<N>>),
-    /// A borrowed sensor handle.
-    Sensor(Ref<'a, Sensor<N>>)
-}
-
-/// Mutable reference to a world object.
-pub enum WorldObjectBorrowedMut<'a, N: Real> {
-    /// A mutably borrowed rigid body handle.
-    RigidBody(RefMut<'a, RigidBody<N>>),
-    /// A mutably borrowed sensor handle.
-    Sensor(RefMut<'a, Sensor<N>>)
-}
-
-impl<N: Real> WorldObject<N> {
-    /// The unique identifier a rigid body would have if it was wrapped on a `WorldObject`.
-    ///
-    /// This identifier remains unique and will not change as long as `rb` is kept alive in memory.
-    #[inline]
-    pub fn rigid_body_uid(rb: &RigidBodyHandle<N>) -> usize {
-        &**rb as *const RefCell<RigidBody<N>> as usize
-    }
-
-    /// The unique identifier a sensor would have if it was wrapped on a `WorldObject`.
-    ///
-    /// This identifier remains unique and will not change as long as `s` is kept alive in memory.
-    #[inline]
-    pub fn sensor_uid(s: &SensorHandle<N>) -> usize {
-        &**s  as *const RefCell<Sensor<N>> as usize
-    }
-
+impl WorldObject {
     /// Whether or not this is a rigid body.
     #[inline]
     pub fn is_rigid_body(&self) -> bool {
@@ -67,7 +28,7 @@ impl<N: Real> WorldObject<N> {
 
     /// Unwraps this object as a sensor or fails.
     #[inline]
-    pub fn unwrap_sensor(self) -> SensorHandle<N> {
+    pub fn unwrap_sensor(self) -> usize {
         match self {
             WorldObject::Sensor(s) => s,
             _                      => panic!("This world object is not a sensor.")
@@ -76,9 +37,9 @@ impl<N: Real> WorldObject<N> {
 
     /// Unwraps this object as a rigid body or fails.
     #[inline]
-    pub fn unwrap_rigid_body(self) -> RigidBodyHandle<N> {
+    pub fn unwrap_rigid_body(self) -> usize {
         match self {
-            WorldObject::RigidBody(rb) => rb.clone(),
+            WorldObject::RigidBody(rb) => rb,
             _                          => panic!("This world object is not a rigid body.")
         }
     }
@@ -87,116 +48,35 @@ impl<N: Real> WorldObject<N> {
     #[inline]
     pub fn uid(&self) -> usize {
         match *self {
-            WorldObject::RigidBody(ref rb) => WorldObject::rigid_body_uid(rb),
-            WorldObject::Sensor(ref s)     => WorldObject::sensor_uid(s)
+            WorldObject::RigidBody(uid) => uid,
+            WorldObject::Sensor(uid)    => uid,
         }
     }
 
-    /// Borrows this world object.
-    #[inline]
-    pub fn borrow(&self) -> WorldObjectBorrowed<N> {
-        match *self {
-            WorldObject::RigidBody(ref rb) => WorldObjectBorrowed::RigidBody(rb.borrow()),
-            WorldObject::Sensor(ref s)     => WorldObjectBorrowed::Sensor(s.borrow())
-        }
-    }
+    // TODO: delete ?
+    // #[inline]
+    // pub fn position(&self) -> Isometry<N> {
+    //     match *self {
+    //         WorldObject::RigidBody(ref rb) => rb.position().clone(),
+    //         WorldObject::Sensor(ref s)     => s.position()
+    //     }
+    // }
 
-    /// Borrows this world object as a sensor.
-    #[inline]
-    pub fn borrow_sensor(&self) -> Ref<Sensor<N>> {
-        match *self {
-            WorldObject::Sensor(ref s) => s.borrow(),
-            _                          => panic!("This world object is not a sensor.")
-        }
-    }
+    // /// A reference to this object geometrical shape.
+    // #[inline]
+    // pub fn shape(&self) -> &ShapeHandle<Point<N>, Isometry<N>> {
+    //     match *self {
+    //         WorldObject::RigidBody(ref rb) => rb.shape(),
+    //         WorldObject::Sensor(ref s)     => s.shape()
+    //     }
+    // }
 
-    /// Borrows this world object as a rigid body.
-    #[inline]
-    pub fn borrow_rigid_body(&self) -> Ref<RigidBody<N>> {
-        match *self {
-            WorldObject::RigidBody(ref rb) => rb.borrow(),
-            _                              => panic!("This world object is not a rigid body.")
-        }
-    }
-
-    /// Mutably borrows this world object.
-    #[inline]
-    pub fn borrow_mut(&mut self) -> WorldObjectBorrowedMut<N> {
-        match *self {
-            WorldObject::RigidBody(ref mut rb) => WorldObjectBorrowedMut::RigidBody(rb.borrow_mut()),
-            WorldObject::Sensor(ref mut s)     => WorldObjectBorrowedMut::Sensor(s.borrow_mut())
-        }
-    }
-
-    /// Mutably borrows this world object as a sensor.
-    #[inline]
-    pub fn borrow_mut_sensor(&mut self) -> RefMut<Sensor<N>> {
-        match *self {
-            WorldObject::Sensor(ref mut s) => s.borrow_mut(),
-            _                              => panic!("This world object is not a sensor.")
-        }
-    }
-
-    /// Mutably borrows this world object as a rigid body.
-    #[inline]
-    pub fn borrow_mut_rigid_body(&mut self) -> RefMut<RigidBody<N>> {
-        match *self {
-            WorldObject::RigidBody(ref mut rb) => rb.borrow_mut(),
-            _                                  => panic!("This world object is not a rigid body.")
-        }
-    }
+    // /// This object margin.
+    // #[inline]
+    // pub fn margin(&self) -> N {
+    //     match *self {
+    //         WorldObject::RigidBody(ref rb) => rb.margin(),
+    //         WorldObject::Sensor(ref s)     => s.margin()
+    //     }
+    // }
 }
-
-macro_rules! impl_getters(
-    ($t: ident) => (
-        impl<'a, N: Real> $t<'a, N> {
-            /// This object's position.
-            #[inline]
-            pub fn position(&self) -> Isometry<N> {
-                match *self {
-                    $t::RigidBody(ref rb) => rb.position().clone(),
-                    $t::Sensor(ref s)     => s.position()
-                }
-            }
-
-            /// A reference to this object geometrical shape.
-            #[inline]
-            pub fn shape(&self) -> &ShapeHandle<Point<N>, Isometry<N>> {
-                match *self {
-                    $t::RigidBody(ref rb) => rb.shape(),
-                    $t::Sensor(ref s)     => s.shape()
-                }
-            }
-
-            /// This object margin.
-            #[inline]
-            pub fn margin(&self) -> N {
-                match *self {
-                    $t::RigidBody(ref rb) => rb.margin(),
-                    $t::Sensor(ref s)     => s.margin()
-                }
-            }
-
-            /// Whether or not this is a rigid body.
-            #[inline]
-            pub fn is_rigid_body(&self) -> bool {
-                match *self {
-                    $t::RigidBody(_) => true,
-                    _                => false
-                }
-            }
-
-            /// Whether or not this is a sensor.
-            #[inline]
-            pub fn is_sensor(&self) -> bool {
-                match *self {
-                    $t::Sensor(_) => true,
-                    _             => false
-                }
-            }
-        }
-    )
-);
-
-impl_getters!(WorldObjectBorrowed);
-impl_getters!(WorldObjectBorrowedMut);

--- a/src/resolution/solver.rs
+++ b/src/resolution/solver.rs
@@ -1,7 +1,8 @@
 use alga::general::Real;
+use world::RigidBodyStorage;
 
 /// Trait implemented by constraint solvers.
 pub trait Solver<N: Real, I> {
     /// Solve the set of constraints of type `I`.
-    fn solve(&mut self, N, &[I]);
+    fn solve(&mut self, N, &[I], &mut RigidBodyStorage<N>);
 }

--- a/src/utils/index_vector.rs
+++ b/src/utils/index_vector.rs
@@ -1,0 +1,97 @@
+// TODO: not very safe as there is no max bound
+use std::ops::{Index, IndexMut};
+use std::slice::{Iter, IterMut};
+use std::iter::FilterMap;
+
+pub trait Indexable {
+    fn set_index(&mut self, index: usize);
+}
+
+pub type IndexVecIter<'a, T> = FilterMap<Iter<'a, Option<T>>, fn(&Option<T>) -> Option<&T>>;
+pub type IndexVecIterMut<'a, T> = FilterMap<IterMut<'a, Option<T>>, fn(&mut Option<T>) -> Option<&mut T>>;
+
+/// Element in this vector never change their position in the vector
+pub struct IndexVec<T> {
+    data: Vec<Option<T>>,
+    empty: Vec<usize>,
+    len: usize,
+    offset: usize,
+}
+
+impl<T> IndexVec<T> {
+    pub fn new(offset: usize) -> Self {
+        IndexVec {
+            data: vec!(),
+            empty: Vec::new(),
+            len: 0,
+            offset
+        }
+    }
+
+    fn take_next_index(&mut self) -> usize {
+        self.len += 1;
+        if let Some(index) = self.empty.pop() {
+            index
+        } else {
+            self.data.push(None);
+            self.data.len() - 1
+        }
+    }
+
+    pub fn insert(&mut self, data: T) -> usize {
+        let index = self.take_next_index();
+        self.data[index] = Some(data);
+        index + self.offset
+    }
+
+    pub fn remove(&mut self, mut index: usize) -> T {
+        index -= self.offset;
+        self.empty.push(index);
+        self.len -= 1;
+        self.data[index].take().unwrap()
+    }
+
+    pub fn iter(&self) -> IndexVecIter<T> {
+        fn fn_as_ref<T>(d: &Option<T>) -> Option<&T> {
+            d.as_ref()
+        }
+        self.data.iter().filter_map(fn_as_ref)
+    }
+
+    pub fn iter_mut(&mut self) -> IndexVecIterMut<T> {
+        fn fn_as_mut<T>(d: &mut Option<T>) -> Option<&mut T> {
+            d.as_mut()
+        }
+        self.data.iter_mut().filter_map(fn_as_mut)
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.len
+    }
+}
+
+impl<T: Indexable> IndexVec<T> {
+    #[inline]
+    pub fn insert_and_set_index(&mut self, mut data: T) -> usize {
+        let index = self.take_next_index();
+        data.set_index(index + self.offset);
+        self.data[index] = Some(data);
+        index + self.offset
+    }
+}
+
+impl<T: Indexable> Index<usize> for IndexVec<T> {
+    type Output = T;
+    #[inline]
+    fn index(&self, index: usize) -> &T {
+        self.data[index - self.offset].as_ref().unwrap()
+    }
+}
+
+impl<T: Indexable> IndexMut<usize> for IndexVec<T> {
+    #[inline]
+    fn index_mut(&mut self, index: usize) -> &mut T {
+        self.data[index - self.offset].as_mut().unwrap()
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -2,7 +2,9 @@
 
 pub use self::deterministic_state::DeterministicState;
 pub use self::generalized_cross::GeneralizedCross;
+pub use self::index_vector::{IndexVec, Indexable, IndexVecIterMut, IndexVecIter};
 
 pub mod union_find;
 mod deterministic_state;
 mod generalized_cross;
+mod index_vector;

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,6 +1,6 @@
 //! The physics world.
 
 pub use world::world::{World, WorldBroadPhase, RigidBodies, Sensors, RigidBodyCollisionWorld,
-                       WorldCollisionObject};
+                       WorldCollisionObject, RigidBodyStorage, SensorStorage};
 
 mod world;

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -378,6 +378,14 @@ impl<N: Real> World<N> {
     pub fn unregister_broad_phase_pair_filter(&mut self, name: &str) {
         self.cworld.unregister_broad_phase_pair_filter(name)
     }
+
+    pub fn sensor(&self, sensor: usize) -> &Sensor<N> {
+        &self.sensors[sensor]
+    }
+
+    pub fn mut_sensor(&mut self, sensor: usize) -> &mut Sensor<N> {
+        &mut self.sensors[sensor]
+    }
 }
 
 struct SensorsNotCollidingTheirParentPairFilter;

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -152,12 +152,12 @@ impl<N: Real> World<N> {
         // reactivate sleeping objects that loose contact.
         for contact_event in self.cworld.contact_events() {
             if let &ContactEvent::Started(obj1, obj2) = contact_event {
-                let data_obj1 = &self.cworld.collision_object(obj1).unwrap().data;
-                let data_obj2 = &self.cworld.collision_object(obj2).unwrap().data;
-
-                if let (&WorldObject::RigidBody(rb1), &WorldObject::RigidBody(rb2)) = (data_obj1, data_obj2){
-                    self.sleep.deferred_activate(&self.rigid_bodies[rb1]);
-                    self.sleep.deferred_activate(&self.rigid_bodies[rb2]);
+                for &obj in [obj1, obj2].iter() {
+                    if let Some(obj) = self.cworld.collision_object(obj) {
+                        if let WorldObject::RigidBody(rb) = obj.data {
+                            self.sleep.deferred_activate(&self.rigid_bodies[rb]);
+                        }
+                    }
                 }
             }
         }

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -163,14 +163,17 @@ impl<N: Real> World<N> {
         }
 
         for proximity_event in self.cworld.proximity_events() {
-            let o1 = &self.cworld.collision_object(proximity_event.co1).unwrap().data;
-            let o2 = &self.cworld.collision_object(proximity_event.co2).unwrap().data;
-            sensor_handle_proximity(
-                o1, o2,
-                proximity_event.prev_status,
-                proximity_event.new_status,
-                &mut self.sensors
-            )
+            let o1 = self.cworld.collision_object(proximity_event.co1);
+            let o2 = self.cworld.collision_object(proximity_event.co2);
+            match (o1, o2) {
+                (Some(o1), Some(o2)) => sensor_handle_proximity(
+                    &o1.data, &o2.data,
+                    proximity_event.prev_status,
+                    proximity_event.new_status,
+                    &mut self.sensors
+                ),
+                _ => (),
+            }
         }
 
         self.joints.update(&mut self.sleep, &self.rigid_bodies);

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -1,57 +1,59 @@
 use std::slice::Iter;
 use std::iter::Map;
-use std::rc::Rc;
-use std::cell::RefCell;
 
 use alga::general::Real;
 use na;
 use ncollide::bounding_volume::AABB;
-use ncollide::utils::data::hash_map::{HashMap, Entry};
-use ncollide::utils::data::hash::UintTWHash;
+use ncollide::utils::data::hash_map::Entry;
 use ncollide::broad_phase::{DBVTBroadPhase, BroadPhasePairFilter};
-use ncollide::narrow_phase::{ContactHandler, ProximityHandler, DefaultNarrowPhase,
-                             DefaultContactDispatcher, DefaultProximityDispatcher,
-                             ContactAlgorithm};
+use ncollide::narrow_phase::{DefaultNarrowPhase, DefaultContactDispatcher,
+                             DefaultProximityDispatcher};
 use ncollide::world::{CollisionWorld, CollisionObject, GeometricQueryType};
+use ncollide::ncollide_pipeline::events::ContactEvent;
 use integration::{Integrator, BodySmpEulerIntegrator, BodyForceGenerator,
                   TranslationalCCDMotionClamping};
 use detection::ActivationManager;
 use detection::constraint::Constraint;
 use detection::joint::{JointManager, BallInSocket, Fixed};
 use resolution::{Solver, AccumulatedImpulseSolver, CorrectionMode};
-use object::{WorldObject, RigidBody, RigidBodyHandle, Sensor, SensorHandle, SensorProximityCollector};
+use object::{WorldObject, RigidBody, Sensor, sensor_handle_proximity};
 use math::{Point, Vector, Isometry};
+use utils::{IndexVec, IndexVecIter};
 
 /// The default broad phase.
-pub type WorldBroadPhase<N> = DBVTBroadPhase<Point<N>, WorldObject<N>, AABB<Point<N>>>;
+pub type WorldBroadPhase<N> = DBVTBroadPhase<Point<N>, WorldObject, AABB<Point<N>>>;
 
 /// An iterator visiting rigid bodies.
-pub type RigidBodies<'a, N> = Map<Iter<'a, Entry<usize, RigidBodyHandle<N>>>, fn(&'a Entry<usize, RigidBodyHandle<N>>) -> &'a RigidBodyHandle<N>>;
+pub type RigidBodies<'a> = Map<Iter<'a, Entry<usize, ()>>, fn(&'a Entry<usize, ()>) -> usize>;
 
 /// An iterator visiting sensors.
-pub type Sensors<'a, N> = Map<Iter<'a, Entry<usize, SensorHandle<N>>>, fn(&'a Entry<usize, SensorHandle<N>>) -> &'a SensorHandle<N>>;
+pub type Sensors<'a> = Map<Iter<'a, Entry<usize, ()>>, fn(&'a Entry<usize, ()>) -> usize>;
+
+type FilterData<N> = SensorStorage<N>;
 
 /// Type of the collision world containing rigid bodies.
-pub type RigidBodyCollisionWorld<N> = CollisionWorld<Point<N>, Isometry<N>, WorldObject<N>>;
+pub type RigidBodyCollisionWorld<N> = CollisionWorld<Point<N>, Isometry<N>, WorldObject, FilterData<N>>;
 
 /// Type of a collision object containing `WorldObject` body as its data.
-pub type WorldCollisionObject<N> = CollisionObject<Point<N>, Isometry<N>, WorldObject<N>>;
+pub type WorldCollisionObject<N> = CollisionObject<Point<N>, Isometry<N>, WorldObject>;
 
+pub type RigidBodyStorage<N> = IndexVec<RigidBody<N>>;
+pub type SensorStorage<N> = IndexVec<Sensor<N>>;
 
 /// The physical world.
 ///
 /// This is the main structure of the physics engine.
 pub struct World<N: Real> {
-    cworld:       RigidBodyCollisionWorld<N>,
-    rigid_bodies: HashMap<usize, RigidBodyHandle<N>, UintTWHash>,
-    sensors:      HashMap<usize, SensorHandle<N>, UintTWHash>,
-    forces:       BodyForceGenerator<N>,
-    integrator:   BodySmpEulerIntegrator,
-    sleep:        Rc<RefCell<ActivationManager<N>>>, // FIXME: avoid sharing (needed for the contact signal handler)
-    ccd:          TranslationalCCDMotionClamping<N>,
-    joints:       JointManager<N>,
-    solver:       AccumulatedImpulseSolver<N>,
-    prediction:   N
+    cworld:              RigidBodyCollisionWorld<N>,
+    rigid_bodies:        IndexVec<RigidBody<N>>,
+    sensors:             IndexVec<Sensor<N>>,
+    forces:              BodyForceGenerator<N>,
+    integrator:          BodySmpEulerIntegrator,
+    sleep:               ActivationManager<N>,
+    ccd:                 TranslationalCCDMotionClamping<N>,
+    joints:              JointManager<N>,
+    solver:              AccumulatedImpulseSolver<N>,
+    prediction:          N,
 }
 
 impl<N: Real> World<N> {
@@ -83,22 +85,13 @@ impl<N: Real> World<N> {
         let ccd = TranslationalCCDMotionClamping::new();
 
         // Deactivation
-        let sleep = Rc::new(RefCell::new(ActivationManager::new(na::convert(0.01f64))));
-
-        // Setup contact handler to reactivate sleeping objects that loose contact.
-        let handler = ObjectActivationOnContactHandler { sleep: sleep.clone() };
-        cworld.register_contact_handler("__nphysics_internal_ObjectActivationOnContactHandler", handler);
+        let activation_manager = ActivationManager::new(na::convert(0.01f64));
 
         // Setup the broad phase pair filter that will prevent sensors from colliding with their
         // parent.
         let filter      = SensorsNotCollidingTheirParentPairFilter;
         let filter_name = "__nphysics_internal_SensorsNotCollidingTheirParentPairFilter";
         cworld.register_broad_phase_pair_filter(filter_name, filter);
-
-        // Setup the proximity collector for sensors.
-        let collector      = SensorProximityCollector;
-        let collector_name = "__nphysics_internal_SensorProximityCollector";
-        cworld.register_proximity_handler(collector_name, collector);
 
         // Joints
         let joints = JointManager::new();
@@ -115,133 +108,146 @@ impl<N: Real> World<N> {
             10);
 
         World {
-            cworld:       cworld,
-            rigid_bodies: HashMap::new(UintTWHash::new()),
-            sensors:      HashMap::new(UintTWHash::new()),
-            forces:       forces,
-            integrator:   integrator,
-            sleep:        sleep,
-            ccd:          ccd,
-            joints:       joints,
-            solver:       solver,
-            prediction:   prediction
+            cworld:             cworld,
+            rigid_bodies:       IndexVec::new(0),
+            sensors:            IndexVec::new(1<<30),
+            forces:             forces,
+            integrator:         integrator,
+            sleep:              activation_manager,
+            ccd:                ccd,
+            joints:             joints,
+            solver:             solver,
+            prediction:         prediction,
         }
     }
 
     /// Updates the physics world.
     pub fn step(&mut self, dt: N) {
-        for e in self.rigid_bodies.elements_mut().iter_mut() {
-            let mut rb = e.value.borrow_mut();
-
+        for rb in self.rigid_bodies.iter_mut() {
             if rb.is_active() {
-                self.forces.update(dt.clone(), &mut *rb);
-                self.integrator.update(dt.clone(), &mut *rb);
-                self.cworld.deferred_set_position(WorldObject::rigid_body_uid(&e.value), rb.position().clone());
+                self.forces.update(dt.clone(), rb);
+                self.integrator.update(dt.clone(), rb);
+                self.cworld.deferred_set_position(rb.uid(), rb.position().clone());
             }
         }
 
-        for e in self.sensors.elements_mut().iter_mut() {
-            let mut sensor = e.value.borrow_mut();
-
+        for sensor in self.sensors.iter_mut() {
             if sensor.did_move_locally {
                 sensor.did_move_locally = false;
-                self.cworld.deferred_set_position(WorldObject::sensor_uid(&e.value), sensor.position());
+                self.cworld.deferred_set_position(sensor.uid(), sensor.position(&self.rigid_bodies));
             }
-            else {
-                if let Some(rb) = sensor.parent() {
-                    if rb.borrow().is_active() {
-                        self.cworld.deferred_set_position(WorldObject::sensor_uid(&e.value), sensor.position());
-                    }
+            else if let Some(&rb) = sensor.parent() {
+                if self.rigid_bodies[rb].is_active() {
+                    self.cworld.deferred_set_position(sensor.uid(), sensor.position(&self.rigid_bodies));
                 }
             }
         }
 
         self.cworld.perform_position_update();
-        self.cworld.perform_broad_phase();
-        if !self.ccd.update(&mut self.cworld) {
+        self.cworld.perform_broad_phase(&self.sensors);
+        if !self.ccd.update(&mut self.cworld, &mut self.rigid_bodies, &mut self.sensors) {
             self.cworld.perform_narrow_phase();
         }
 
-        self.joints.update(&mut *self.sleep.borrow_mut());
-        self.sleep.borrow_mut().update(&mut self.cworld, &self.joints, &self.rigid_bodies);
+        // reactivate sleeping objects that loose contact.
+        for contact_event in self.cworld.contact_events() {
+            if let &ContactEvent::Started(obj1, obj2) = contact_event {
+                let data_obj1 = &self.cworld.collision_object(obj1).unwrap().data;
+                let data_obj2 = &self.cworld.collision_object(obj2).unwrap().data;
+
+                if let (&WorldObject::RigidBody(rb1), &WorldObject::RigidBody(rb2)) = (data_obj1, data_obj2){
+                    self.sleep.deferred_activate(&self.rigid_bodies[rb1]);
+                    self.sleep.deferred_activate(&self.rigid_bodies[rb2]);
+                }
+            }
+        }
+
+        for proximity_event in self.cworld.proximity_events() {
+            let o1 = &self.cworld.collision_object(proximity_event.co1).unwrap().data;
+            let o2 = &self.cworld.collision_object(proximity_event.co2).unwrap().data;
+            sensor_handle_proximity(
+                o1, o2,
+                proximity_event.prev_status,
+                proximity_event.new_status,
+                &mut self.sensors
+            )
+        }
+
+        self.joints.update(&mut self.sleep, &self.rigid_bodies);
+        self.sleep.update(&mut self.cworld, &self.joints, &mut self.rigid_bodies);
 
         // XXX: use `self.collector` instead to avoid allocation.
         let mut collector = Vec::new();
 
         for (b1, b2, c) in self.cworld.contacts() {
-            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
-                if rb1.borrow().is_active() || rb2.borrow().is_active() {
-                    let m1 = rb1.borrow().margin();
-                    let m2 = rb2.borrow().margin();
+            if let (&WorldObject::RigidBody(rb1_uid), &WorldObject::RigidBody(rb2_uid)) = (&b1.data, &b2.data) {
+                let rb1 = &self.rigid_bodies[rb1_uid];
+                let rb2 = &self.rigid_bodies[rb2_uid];
+                if rb1.is_active() || rb2.is_active() {
+                    let m1 = rb1.margin();
+                    let m2 = rb2.margin();
 
                     let mut c = c.clone();
                     c.depth = c.depth + m1 + m2;
 
-                    collector.push(Constraint::RBRB(rb1.clone(), rb2.clone(), c));
+                    collector.push(Constraint::RBRB(rb1_uid, rb2_uid, c));
                 }
             }
         }
 
         self.joints.constraints(&mut collector);
 
-        self.solver.solve(dt, &collector[..]);
+        self.solver.solve(dt, &collector[..], &mut self.rigid_bodies);
 
         collector.clear();
     }
 
     /// Adds a rigid body to the physics world.
-    pub fn add_rigid_body(&mut self, rb: RigidBody<N>) -> RigidBodyHandle<N> {
+    pub fn add_rigid_body(&mut self, rb: RigidBody<N>) -> usize {
         let position = rb.position().clone();
         let shape = rb.shape().clone();
         let groups = rb.collision_groups().as_collision_groups().clone();
         let collision_object_prediction = rb.margin() + self.prediction / na::convert(2.0f64);
-        let handle = Rc::new(RefCell::new(rb));
-        let uid = WorldObject::rigid_body_uid(&handle);
 
-        let _ = self.rigid_bodies.insert(uid, handle.clone());
+        let uid = self.rigid_bodies.insert_and_set_index(rb);
         self.cworld.deferred_add(uid, position, shape, groups,
                                  GeometricQueryType::Contacts(collision_object_prediction),
-                                 WorldObject::RigidBody(handle.clone()));
-        self.cworld.perform_additions_removals_and_broad_phase();
-
-        handle
+                                 WorldObject::RigidBody(uid));
+        self.cworld.perform_additions_removals_and_broad_phase(&self.sensors);
+        uid
     }
 
     /// Adds a sensor to the physics world.
-    pub fn add_sensor(&mut self, sensor: Sensor<N>) -> SensorHandle<N> {
-        let position = sensor.position().clone();
+    pub fn add_sensor(&mut self, sensor: Sensor<N>) -> usize {
+        let position = sensor.position(&self.rigid_bodies).clone();
         let shape    = sensor.shape().clone();
         let groups   = sensor.collision_groups().as_collision_groups().clone();
         let margin   = sensor.margin();
-        let handle   = Rc::new(RefCell::new(sensor));
-        let uid      = &*handle as *const RefCell<Sensor<N>> as usize;
 
-        let _ = self.sensors.insert(uid, handle.clone());
+        let uid = self.sensors.insert_and_set_index(sensor);
         self.cworld.deferred_add(uid, position, shape, groups,
                                  GeometricQueryType::Proximity(margin),
-                                 WorldObject::Sensor(handle.clone()));
-        self.cworld.perform_additions_removals_and_broad_phase();
-
-        handle
+                                 WorldObject::Sensor(uid));
+        self.cworld.perform_additions_removals_and_broad_phase(&self.sensors);
+        uid
     }
 
     /// Remove a rigid body from the physics world.
-    pub fn remove_rigid_body(&mut self, rb: &RigidBodyHandle<N>) {
-        let uid = WorldObject::rigid_body_uid(rb);
+    pub fn remove_rigid_body(&mut self, uid: usize) {
         self.cworld.deferred_remove(uid);
-        self.cworld.perform_additions_removals_and_broad_phase();
-        self.joints.remove(rb, &mut *self.sleep.borrow_mut());
-        self.ccd.remove_ccd_from(rb);
-        let _ = self.rigid_bodies.remove(&uid);
-        rb.borrow_mut().delete();
+        self.cworld.perform_additions_removals_and_broad_phase(&self.sensors);
+        self.joints.remove(uid, &mut self.sleep, &self.rigid_bodies);
+        self.ccd.remove_ccd_from(uid);
+        let mut rb = self.rigid_bodies.remove(uid);
+        // TODO: do it ? this doesn't have much sense now.
+        rb.delete();
     }
 
     /// Remove a sensor from the physics world.
-    pub fn remove_sensor(&mut self, sensor: &SensorHandle<N>) {
-        let uid = WorldObject::sensor_uid(sensor);
+    pub fn remove_sensor(&mut self, uid: usize) {
         self.cworld.deferred_remove(uid);
-        self.cworld.perform_additions_removals_and_broad_phase();
-        let _ = self.sensors.remove(&uid);
+        self.cworld.perform_additions_removals_and_broad_phase(&self.sensors);
+        let _ = self.sensors.remove(uid);
     }
 
     // XXX: keep this reference mutable?
@@ -303,50 +309,44 @@ impl<N: Real> World<N> {
     ///
     /// Set `trigger_sensor` to `true` if the rigid body should active the sensors that would have
     /// been missed without CCD enabled.
-    pub fn add_ccd_to(&mut self, body: &RigidBodyHandle<N>, motion_thresold: N, trigger_sensors: bool) {
-        self.ccd.add_ccd_to(body.clone(), motion_thresold, trigger_sensors)
+    pub fn add_ccd_to(&mut self, body: usize, motion_thresold: N, trigger_sensors: bool) {
+        unimplemented!();
+        // self.ccd.add_ccd_to(body.clone(), motion_thresold, trigger_sensors)
     }
 
     /// Adds a ball-in-socket joint to the world.
-    pub fn add_ball_in_socket(&mut self, joint: BallInSocket<N>) -> Rc<RefCell<BallInSocket<N>>> {
-        let res = Rc::new(RefCell::new(joint));
-
-        self.joints.add_ball_in_socket(res.clone(), &mut *self.sleep.borrow_mut());
-
-        res
+    pub fn add_ball_in_socket(&mut self, joint: BallInSocket<N>) -> usize {
+        self.joints.add_ball_in_socket(joint, &mut self.sleep, &self.rigid_bodies)
     }
 
     /// Removes a ball-in-socket joint from the world.
-    pub fn remove_ball_in_socket(&mut self, joint: &Rc<RefCell<BallInSocket<N>>>) {
-        self.joints.remove_ball_in_socket(joint, &mut *self.sleep.borrow_mut())
+    pub fn remove_ball_in_socket(&mut self, joint: usize) {
+        self.joints.remove_ball_in_socket(joint, &mut self.sleep, &self.rigid_bodies)
     }
 
     /// Adds a fixed joint to the world.
-    pub fn add_fixed(&mut self, joint: Fixed<N>) -> Rc<RefCell<Fixed<N>>> {
-        let res = Rc::new(RefCell::new(joint));
-
-        self.joints.add_fixed(res.clone(), &mut *self.sleep.borrow_mut());
-
-        res
+    pub fn add_fixed(&mut self, joint: Fixed<N>) -> usize {
+        self.joints.add_fixed(joint, &mut self.sleep, &self.rigid_bodies)
     }
 
     /// Removes a fixed joint from the world.
-    pub fn remove_fixed(&mut self, joint: &Rc<RefCell<Fixed<N>>>) {
-        self.joints.remove_joint(joint, &mut *self.sleep.borrow_mut())
+    pub fn remove_fixed(&mut self, joint: usize) {
+        // TODO: need stronger type for joint to differentiate f from bis
+        self.joints.remove_joint::<Fixed<N>, _>(joint, &mut self.sleep, &self.rigid_bodies)
     }
 
     /// Collects every constraincts detected since the last update.
     pub fn constraints(&mut self, out: &mut Vec<Constraint<N>>) {
         // FIXME: ugly.
         for (b1, b2, c) in self.cworld.contacts() {
-            if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&b1.data, &b2.data) {
-                let m1 = rb1.borrow().margin();
-                let m2 = rb2.borrow().margin();
+            if let (&WorldObject::RigidBody(rb1), &WorldObject::RigidBody(rb2)) = (&b1.data, &b2.data) {
+                let m1 = self.rigid_bodies[rb1].margin();
+                let m2 = self.rigid_bodies[rb2].margin();
 
                 let mut c = c.clone();
                 c.depth = c.depth + m1 + m2;
 
-                out.push(Constraint::RBRB(rb1.clone(), rb2.clone(), c));
+                out.push(Constraint::RBRB(rb1, rb2, c));
             }
         }
 
@@ -354,23 +354,13 @@ impl<N: Real> World<N> {
     }
 
     /// An iterator visiting all rigid bodies on this world.
-    pub fn rigid_bodies(&self) -> RigidBodies<N> {
-        fn extract_value<N: Real>(e: &Entry<usize, RigidBodyHandle<N>>) -> &RigidBodyHandle<N> {
-            &e.value
-        }
-
-        let extract_value_fn: fn(_) -> _ = extract_value;
-        self.rigid_bodies.elements().iter().map(extract_value_fn)
+    pub fn rigid_bodies(&self) -> IndexVecIter<RigidBody<N>> {
+        self.rigid_bodies.iter()
     }
 
     /// An iterator visiting all sensors on this world.
-    pub fn sensors(&self) -> Sensors<N> {
-        fn extract_value<N: Real>(e: &Entry<usize, SensorHandle<N>>) -> &SensorHandle<N> {
-            &e.value
-        }
-
-        let extract_value_fn: fn(_) -> _ = extract_value;
-        self.sensors.elements().iter().map(extract_value_fn)
+    pub fn sensors(&self) -> IndexVecIter<Sensor<N>> {
+        self.sensors.iter()
     }
 
     /// Adds a filter that tells if a potential collision pair should be ignored or not.
@@ -380,7 +370,7 @@ impl<N: Real> World<N> {
     /// a non-trivial overhead during the next update as it will force re-detection of all
     /// collision pairs.
     pub fn register_broad_phase_pair_filter<F>(&mut self, name: &str, filter: F)
-        where F: BroadPhasePairFilter<Point<N>, Isometry<N>, WorldObject<N>> + 'static {
+        where F: BroadPhasePairFilter<Point<N>, Isometry<N>, WorldObject, FilterData<N>> {
         self.cworld.register_broad_phase_pair_filter(name, filter)
     }
 
@@ -388,69 +378,22 @@ impl<N: Real> World<N> {
     pub fn unregister_broad_phase_pair_filter(&mut self, name: &str) {
         self.cworld.unregister_broad_phase_pair_filter(name)
     }
-
-    /// Registers a handler for contact start/stop events.
-    pub fn register_contact_handler<H>(&mut self, name: &str, handler: H)
-        where H: ContactHandler<Point<N>, Isometry<N>, WorldObject<N>> + 'static {
-        self.cworld.register_contact_handler(name, handler)
-    }
-
-    /// Unregisters a handler for contact start/stop events.
-    pub fn unregister_contact_handler(&mut self, name: &str) {
-        self.cworld.unregister_contact_handler(name)
-    }
-
-    /// Registers a handler for proximity status change events.
-    pub fn register_proximity_handler<H>(&mut self, name: &str, handler: H)
-        where H: ProximityHandler<Point<N>, Isometry<N>, WorldObject<N>> + 'static {
-        self.cworld.register_proximity_handler(name, handler);
-    }
-
-    /// Unregisters a handler for proximity status change events.
-    pub fn unregister_proximity_handler(&mut self, name: &str) {
-        self.cworld.unregister_proximity_handler(name);
-    }
-}
-
-struct ObjectActivationOnContactHandler<N: Real> {
-    sleep: Rc<RefCell<ActivationManager<N>>>
-}
-
-impl<N: Real> ContactHandler<Point<N>, Isometry<N>, WorldObject<N>>
-for ObjectActivationOnContactHandler<N> {
-    #[inline]
-    fn handle_contact_started(&mut self,
-                              _: &WorldCollisionObject<N>,
-                              _: &WorldCollisionObject<N>,
-                              _: &ContactAlgorithm<Point<N>, Isometry<N>>) {
-        // Do nothing.
-    }
-
-    fn handle_contact_stopped(&mut self, obj1: &WorldCollisionObject<N>, obj2: &WorldCollisionObject<N>) {
-        // Wake up on collision lost.
-
-        // There is no need to wake up anything if a rigid-body intersects a sensor.
-        if let (&WorldObject::RigidBody(ref rb1), &WorldObject::RigidBody(ref rb2)) = (&obj1.data, &obj2.data) {
-            self.sleep.borrow_mut().deferred_activate(rb1);
-            self.sleep.borrow_mut().deferred_activate(rb2);
-        }
-    }
 }
 
 struct SensorsNotCollidingTheirParentPairFilter;
 
-impl<N: Real> BroadPhasePairFilter<Point<N>, Isometry<N>, WorldObject<N>>
+impl<N: Real> BroadPhasePairFilter<Point<N>, Isometry<N>, WorldObject, FilterData<N>>
 for SensorsNotCollidingTheirParentPairFilter {
     #[inline]
-    fn is_pair_valid(&self, b1: &WorldCollisionObject<N>, b2: &WorldCollisionObject<N>) -> bool {
+    fn is_pair_valid(&self, b1: &WorldCollisionObject<N>, b2: &WorldCollisionObject<N>, sensors: &FilterData<N>) -> bool {
         match (&b1.data, &b2.data) {
-            (&WorldObject::RigidBody(ref rb), &WorldObject::Sensor(ref s)) |
-            (&WorldObject::Sensor(ref s), &WorldObject::RigidBody(ref rb)) => {
-                let bs = s.borrow();
+            (&WorldObject::RigidBody(rb), &WorldObject::Sensor(s)) |
+            (&WorldObject::Sensor(s), &WorldObject::RigidBody(rb)) => {
+                let bs = &sensors[s];
 
-                if let Some(parent) = bs.parent() {
-                    WorldObject::rigid_body_uid(rb) != WorldObject::rigid_body_uid(parent) ||
-                    bs.proximity_with_parent_enabled()
+                if let Some(&parent) = bs.parent() {
+                    // TODO: parent is of type rigidbody ? Have a more stronger type here.
+                    rb != parent || bs.proximity_with_parent_enabled()
                 }
                 else {
                     true

--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -386,6 +386,14 @@ impl<N: Real> World<N> {
     pub fn mut_sensor(&mut self, sensor: usize) -> &mut Sensor<N> {
         &mut self.sensors[sensor]
     }
+
+    pub fn rigid_body(&self, rigid_body: usize) -> &RigidBody<N> {
+        &self.rigid_bodies[rigid_body]
+    }
+
+    pub fn mut_rigid_body(&mut self, rigid_body: usize) -> &mut RigidBody<N> {
+        &mut self.rigid_bodies[rigid_body]
+    }
 }
 
 struct SensorsNotCollidingTheirParentPairFilter;


### PR DESCRIPTION
This PR is not ready yet. just to show you what I am working on

this implementation allow me to use nphysics with specs. I do that in https://github.com/thiolliere/pepe
I have `nphysics::world::World` as a resource and `RigidBody(usize)` component with method to get reference to the actual rigid body with borrowing the nphysics world resource.

(examples have not been updated)

The whole point was not to use Rc<RefCell<_>> for rigid bodies, sensor
and joint and instead use a storage and an index to handle them.

The storage must be efficient index_vector is my implementation:
it uses a vector to store the data and never move the position of the
elements in the vector. So the index of the vector always point to the
same element.
We use an offset in order to make sensor and rigid_bodies index
different.

still issue:
* fitler data is difficult to use as we can't send a tuple of
  reference to storage because it would imply a use of lifetime that the
  compiler can't handle (or it's me). I wanted `FilterData = (&'a
  RigidBodyStorage, &'a SensorStorage) but I couldn't impl it.

  I think the filter things could be different like instead of register
  callbacks in collision world. callbacks would be stored in world and
  collision_world.perform_broad_phase would have a unique callback
  argument. By doing so all the reference lifetimes would be in the in the
  function and so it should be OK.

  the only drawback of this is that it is to the world to ensure to call
  `broad_phase.deferred_recompute_all_proximities();`
* use my fork of ncollide

still todo:
* documentation
* maybe wrap sensor, joint and rigid_body index in a struct(usize) so user
  can't missuse them.
* API
* also I don't know about performance