### PR TITLE
[WIP] 131 refcell world

### DIFF
--- a/examples2d/balls2.rs
+++ b/examples2d/balls2.rs
@@ -9,6 +9,8 @@ use nphysics2d::object::{BodyHandle, Material};
 use nphysics2d::volumetric::Volumetric;
 use nphysics2d::world::World;
 use nphysics_testbed2d::Testbed;
+use std::sync::Arc;
+use std::sync::Mutex;
 
 const COLLIDER_MARGIN: f32 = 0.01;
 
@@ -80,7 +82,7 @@ fn main() {
     /*
      * Set up the testbed.
      */
-    let mut testbed = Testbed::new(world);
+    let mut testbed = Testbed::new(Arc::new(Mutex::new(world)));
     testbed.look_at(Point2::new(0.0, -2.5), 95.0);
     testbed.run();
 }


### PR DESCRIPTION
**This Pull Request is NOT READY to merge now !**


Referencing https://github.com/sebcrozet/nphysics/issues/131

## Current state
I succeeded in compiling:  
- balls2d official nphysics example, which is working fine.
- [my target repository](https://github.com/Vrixyz/testbed-callback/tree/1-arc-mutex) compiled, but I must have some deadlock in there, I'll figure it out when I come back to it.

I'm opening the pull request to show my progress, and discuss about the shortcomings.

## Attempts
### Very first attempt
Within Testbed, I tried to replace `World` by `&mut World`, no chance in compiling ever after.

### Second attempt
Within Testbed, I tried to add a "WorldOwner", which objective was to own a reference to a &mut World, then have a `retrieve` function to access it.

I lost myself again in [complex lifetime annotations](https://github.com/rust-lang/rust/issues/53343).

### Third attempt
I started small, read [some articles](https://doc.rust-lang.org/book/second-edition/ch15-05-interior-mutability.html) (again)
Then, I used `RefCell<World>` to store a mutable world inside `Testbed`.
Once compiling and at least 1 official example working, I used `Rc<RefCell<World>`.

Balls2d compiled successfully, but not [my reproduction repository](https://github.com/Vrixyz/testbed-callback/tree/1-arc-mutex) : indeed, specs::System needs its resources to be `sync::Send` to be sent beetween threads.

So I tried to `Arc<RefCell<World>>`, but I quickly realized I had no choice but to use `Arc<RefCell<World>>`, since `RefCell` is not `sync::Send`.

## Shortcomings

- I had to remove <nphysics::World> argument from callback : as it is shared, it's useless to pass it there.
- Using Arc<RefCell<World>> is verbose and useless in most usecases, so we're sacrificing quite a lot readability, and @sebcrozet vision for nphysics is simplicity...

### Improvements

Once my use case working, I'll see if I can make both ways compatibles:
- First using a raw `World`, Testbed taking the only ownership to it (current behaviour)
- Second using a complex Arc<Mutex<World>>, allowing other threads to impact on the world, and fixing `specs.rs`compatibility.

An option I think about is similar to my Second attempt, with a Trait being a World getter, we might answer all use cases.

