### PR TITLE
Interferences

### DIFF
--- a/src/world/world.rs
+++ b/src/world/world.rs
@@ -45,8 +45,9 @@ pub struct World<N: Real> {
     forces: Slab<Box<ForceGenerator<N>>>,
     params: IntegrationParameters<N>,
     workspace: MultibodyWorkspace<N>,
-    // Required, because the iterators returned by interferences_* require
-    // a reference to a collision group that outlives the function.
+    /// Required, because the iterators returned by interferences_* require
+    /// a reference to a collision group that outlives the function.
+    /// It's empty because nphysics doesn't have support for collision groups anyways.
     empty_groups: CollisionGroups,
 }
 


### PR DESCRIPTION
This PR adds the same `interferences_*` methods as ncollide, because AFAIK there is currently no way of explicitly querying for interferences from nphysics. (Currently the only way to do this is through sensors, which can be quite cumbersome)