### PR TITLE
Added missing ncollide function

### DIFF
--- a/src/world/geometrical_world.rs
+++ b/src/world/geometrical_world.rs
@@ -347,6 +347,22 @@ impl<N: RealField, Handle: BodyHandle, CollHandle: ColliderHandle>
         pipeline::interferences_with_ray(&colliders, &*self.broad_phase, ray, max_toi, groups)
     }
 
+    /// Computes the closest interference between the rigid bodies on this world and a ray.
+    #[inline]
+    pub fn first_interference_with_ray<
+        'a,
+        'b,
+        Colliders: ColliderSet<N, Handle, Handle = CollHandle>,
+    >(
+        &'a self,
+        colliders: &'a Colliders,
+        ray: &'b Ray<N>,
+        max_toi: N,
+        groups: &'b CollisionGroups,
+    ) -> Option<pipeline::FirstInterferenceWithRay<'a, N, Colliders>> {
+        pipeline::first_interference_with_ray(&colliders, &*self.broad_phase, ray, max_toi, groups)
+    }
+
     /// Computes the interferences between every rigid bodies of a given broad phase, and a point.
     #[inline]
     pub fn interferences_with_point<


### PR DESCRIPTION
Hey, this is a continuation of the PR I helped with on ncollide https://github.com/rustsim/ncollide/pull/320. This PR now adds the ability to access the `first_interference_with_ray` method from ncollide through the `geometrical_world`.

I've tested this using nphysics2d with no issues (getting about a 50% speed up using it though!).