### PR TITLE
Remove unnecessary `format` from assert messages

### DIFF
--- a/src/volumetric/volumetric_convex2.rs
+++ b/src/volumetric/volumetric_convex2.rs
@@ -177,10 +177,9 @@ mod test {
         let actual = cube.unit_angular_inertia();
         assert!(
             relative_eq!(actual, expected),
-            format!(
-                "Inertia values do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia values do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         // convex shape
@@ -196,10 +195,9 @@ mod test {
         let actual = geom.unit_angular_inertia();
         assert!(
             relative_eq!(actual, expected),
-            format!(
-                "Inertia values do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia values do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         // rectangle
@@ -218,10 +216,9 @@ mod test {
         let actual = cube.unit_angular_inertia();
         assert!(
             relative_eq!(actual, expected),
-            format!(
-                "Inertia values do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia values do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         // convex shape
@@ -237,10 +234,9 @@ mod test {
         let actual = geom.unit_angular_inertia();
         assert!(
             relative_eq!(actual, expected),
-            format!(
-                "Inertia values do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia values do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         // triangle
@@ -273,10 +269,9 @@ mod test {
         let actual = geom.unit_angular_inertia();
         assert!(
             relative_eq!(actual, expected),
-            format!(
-                "Inertia values do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia values do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
     }
 }

--- a/src/volumetric/volumetric_convex3.rs
+++ b/src/volumetric/volumetric_convex3.rs
@@ -315,10 +315,9 @@ mod test {
 
         assert!(
             relative_eq!(actual, expected, epsilon = 1.0e-8),
-            format!(
-                "Inertia tensors do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Inertia tensors do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         let (actual_m, _, actual_i) = convex.mass_properties(2.37689);
@@ -326,26 +325,23 @@ mod test {
 
         assert!(
             relative_eq!(&actual, &expected, epsilon = 1.0e-8),
-            format!(
-                "Unit inertia tensors do not match: actual {:?}, expected: {:?}.",
-                actual, expected
-            )
+            "Unit inertia tensors do not match: actual {:?}, expected: {:?}.",
+            actual,
+            expected
         );
 
         assert!(
             relative_eq!(actual_i, expected_i, epsilon = 1.0e-8),
-            format!(
-                "Inertia tensors do not match: actual {:?}, expected: {:?}.",
-                actual_i, expected_i
-            )
+            "Inertia tensors do not match: actual {:?}, expected: {:?}.",
+            actual_i,
+            expected_i
         );
 
         assert!(
             relative_eq!(actual_m, expected_m, epsilon = 1.0e-8),
-            format!(
-                "Masses do not match: actual {}, expected: {}.",
-                actual_m, expected_m
-            )
+            "Masses do not match: actual {}, expected: {}.",
+            actual_m,
+            expected_m
         );
     }
 }


### PR DESCRIPTION
These are raising future-compat warnings, since this will be phased out in the 2021 Rust edition